### PR TITLE
tree.py bug fixes & improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,28 @@ python3 setup.py pytest
 ```
 
 There are some dependencies that are test-only (e.g., will not be listed in the project requirements). If you try and run `pytest` alone, it may fail due to missing dependencies.
+
+## Modules
+
+### `gizmos.tree`
+
+The `tree` module produces a CGI tree browser for a given term contained in a SQL database. The SQL database should be created from OWL using [rdftab](https://github.com/ontodev/rdftab.rs) to ensure it is in the right format.
+
+Usage in the command line:
+```
+python3 -m gizmos.tree [path-to-database] [term] > [output-html]
+```
+
+The `term` should be a CURIE with a prefix already defined in the `prefix` table of the database. If the `term` is not included, the output will show a tree starting at `owl:Thing`.
+
+The links in the tree return query strings with the ID of the term:
+```
+?id=FOO:123
+```
+
+If you provide the `-i`/`--include-db` flag, you will also get the `db` parameter in the query string. The value of this parameter is the base name of the database file.
+```
+?db=bar&id=FOO:123
+```
+
+This can be useful when writing scripts that return trees from different databases.

--- a/gizmos/hiccup.py
+++ b/gizmos/hiccup.py
@@ -1,9 +1,11 @@
-def curie2href(curie):
+def curie2href(curie, db=None):
     """Convert a CURIE to an HREF"""
+    if db:
+        return f"?db={db}&id={curie}".replace("#", "%23")
     return f"?id={curie}".replace("#", "%23")
 
 
-def render(prefixes, element, depth=0):
+def render(prefixes, element, db=None, depth=0):
     """Render hiccup-style HTML vector as HTML."""
     indent = "  " * depth
     if not isinstance(element, list):
@@ -18,7 +20,7 @@ def render(prefixes, element, depth=0):
     if len(element) > 0 and isinstance(element[0], dict):
         attrs = element.pop(0)
         if tag == "a" and "href" not in attrs and "resource" in attrs:
-            attrs["href"] = curie2href(attrs["resource"])
+            attrs["href"] = curie2href(attrs["resource"], db)
         for key, value in attrs.items():
             if key in ["checked"]:
                 if value:
@@ -37,7 +39,7 @@ def render(prefixes, element, depth=0):
                 output += child
             elif isinstance(child, list):
                 try:
-                    output += "\n" + render(prefixes, child, depth=depth + 1)
+                    output += "\n" + render(prefixes, child, db=db, depth=depth + 1)
                     spacing = f"\n{indent}"
                 except Exception as e:
                     raise Exception(f"Bad child in '{element}'", e)

--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -30,9 +30,7 @@ OWL_PREFIX = "http://www.w3.org/2002/07/owl#{}"
 
 
 def main():
-    p = ArgumentParser(
-        "tree.py", description="create an HTML page to display an ontology term"
-    )
+    p = ArgumentParser("tree.py", description="create an HTML page to display an ontology term")
     p.add_argument("db", help="SQLite database")
     p.add_argument("term", help="CURIE of ontology term to display", nargs="*")
     p.add_argument(
@@ -102,9 +100,7 @@ def term2tree(data, treename, term_id, include_db=False):
         if len(children) == max_children:
             total = len(tree["children"])
             attrs = {"href": "javascript:show_children()"}
-            children.append(
-                ["li", {"id": "more"}, ["a", attrs, f"Click to show all {total} ..."]]
-            )
+            children.append(["li", {"id": "more"}, ["a", attrs, f"Click to show all {total} ..."]])
     children = ["ul", {"id": "children"}] + children
     if len(children) == 0:
         children = ""
@@ -147,9 +143,7 @@ def term2tree(data, treename, term_id, include_db=False):
     return hierarchy
 
 
-def term2rdfa(
-    cur, prefixes, treename, stanza, term_id, include_db=False, add_children=None
-):
+def term2rdfa(cur, prefixes, treename, stanza, term_id, include_db=False, add_children=None):
     """Create a hiccup-style HTML vector for the given term."""
     if stanza and len(stanza) == 0:
         return set(), "Not found"
@@ -446,9 +440,7 @@ def terms2rdfa(cur, treename, term_ids, include_db=False):
         for term_id in term_ids:
             cur.execute(f"SELECT * FROM statements WHERE stanza = '{term_id}'")
             stanza = cur.fetchall()
-            p, t = term2rdfa(
-                cur, all_prefixes, treename, stanza, term_id, include_db=include_db
-            )
+            p, t = term2rdfa(cur, all_prefixes, treename, stanza, term_id, include_db=include_db)
             ps.update(p)
             terms.append(t)
 
@@ -546,9 +538,7 @@ def row2o(_stanza, _data, _uber_row):
 
     def getOwlOperands(given_row):
         """Extract all of the operands pointed to by the given row and return them as a list"""
-        LOGGER.debug(
-            "Finding operands for row with predicate: {}".format(given_row["predicate"])
-        )
+        LOGGER.debug("Finding operands for row with predicate: {}".format(given_row["predicate"]))
 
         if not given_row["object"].startswith("_:"):
             LOGGER.debug("Found non-blank operand: {}".format(given_row["object"]))
@@ -568,9 +558,7 @@ def row2o(_stanza, _data, _uber_row):
             inner_subj = inner_row["subject"]
             inner_pred = inner_row["predicate"]
             inner_obj = inner_row["object"]
-            LOGGER.debug(
-                f"Found row with <s,p,o> = <{inner_subj}, {inner_pred}, {inner_obj}>"
-            )
+            LOGGER.debug(f"Found row with <s,p,o> = <{inner_subj}, {inner_pred}, {inner_obj}>")
 
             if inner_pred == "rdf:type":
                 if inner_obj == "owl:Restriction":
@@ -581,27 +569,17 @@ def row2o(_stanza, _data, _uber_row):
                     break
             elif inner_pred == "rdf:rest":
                 if inner_obj != "rdf:nil":
-                    operands.append(
-                        ["span", {"rel": inner_pred}] + getOwlOperands(inner_row)
-                    )
+                    operands.append(["span", {"rel": inner_pred}] + getOwlOperands(inner_row))
                 else:
-                    operands.append(
-                        ["span", {"rel": inner_pred, "resource": "rdf:nil"}]
-                    )
+                    operands.append(["span", {"rel": inner_pred, "resource": "rdf:nil"}])
                 LOGGER.debug(f"Returned from recursing on {inner_pred}")
             elif inner_pred == "rdf:first":
                 if inner_obj.startswith("_:"):
-                    LOGGER.debug(
-                        f"{inner_pred} points to a blank node, following the trail"
-                    )
-                    operands.append(
-                        ["span", {"rel": inner_pred}] + getOwlOperands(inner_row)
-                    )
+                    LOGGER.debug(f"{inner_pred} points to a blank node, following the trail")
+                    operands.append(["span", {"rel": inner_pred}] + getOwlOperands(inner_row))
                     LOGGER.debug(f"Returned from recursing on {inner_pred}")
                 else:
-                    LOGGER.debug(
-                        f"Rendering non-blank object with predicate: {inner_pred}"
-                    )
+                    LOGGER.debug(f"Rendering non-blank object with predicate: {inner_pred}")
                     operands.append(renderNonBlank(inner_row))
 
         return operands
@@ -663,13 +641,9 @@ def row2o(_stanza, _data, _uber_row):
         # via the object of the second row, while 'some' and 'sodium phosphate' are
         # extracted via the predicate and object, respectively, of the third row.
         rdf_type_row = [row for row in given_rows if row["predicate"] == "rdf:type"]
-        property_row = [
-            row for row in given_rows if row["predicate"] == "owl:onProperty"
-        ]
+        property_row = [row for row in given_rows if row["predicate"] == "owl:onProperty"]
         target_row = [
-            row
-            for row in given_rows
-            if row["predicate"] not in ("rdf:type", "owl:onProperty")
+            row for row in given_rows if row["predicate"] not in ("rdf:type", "owl:onProperty")
         ]
         """for rowset in [rdf_type_row, property_row, target_row]:
             if len(rowset) != 1:
@@ -681,17 +655,13 @@ def row2o(_stanza, _data, _uber_row):
         rdf_type_row = rdf_type_row[0]
         if rdf_type_row["object"] != "owl:Restriction":
             LOGGER.error(
-                "Unexpected rdf:type: '{}' found in OWL restriction".format(
-                    rdf_type_row["object"]
-                )
+                "Unexpected rdf:type: '{}' found in OWL restriction".format(rdf_type_row["object"])
             )
             return ["div"]
 
         target_pred = target_row["predicate"]
         target_obj = target_row["object"]
-        LOGGER.debug(
-            "Rendering OWL restriction {} for object {}".format(target_pred, target_obj)
-        )
+        LOGGER.debug("Rendering OWL restriction {} for object {}".format(target_pred, target_obj))
         if target_obj.startswith("_:"):
             inner_rows = [row for row in _stanza if row["subject"] == target_obj]
             target_link = renderOwlClassExpression(inner_rows, target_pred)
@@ -708,10 +678,7 @@ def row2o(_stanza, _data, _uber_row):
 
         return [
             "span",
-            [
-                "span",
-                {"rel": rdf_type_row["predicate"], "resource": rdf_type_row["object"]},
-            ],
+            ["span", {"rel": rdf_type_row["predicate"], "resource": rdf_type_row["object"]},],
             [
                 "a",
                 {"rel": property_row["predicate"], "resource": property_row["object"]},
@@ -750,10 +717,7 @@ def row2o(_stanza, _data, _uber_row):
 
         hiccup = [
             "span",
-            [
-                "span",
-                {"rel": rdf_type_row["predicate"], "resource": rdf_type_row["object"]},
-            ],
+            ["span", {"rel": rdf_type_row["predicate"], "resource": rdf_type_row["object"]},],
         ]
 
         # If `rel` is given, insert the attribute into the second position of the hiccup:
@@ -773,9 +737,7 @@ def row2o(_stanza, _data, _uber_row):
             LOGGER.warning(
                 f"Rendering for <s,p,o> = <{class_subj}, {class_pred}, {class_obj}> not implemented"
             )
-            hiccup.append(
-                ["a", {"rel": class_pred}, _data["labels"].get(class_obj, class_obj)]
-            )
+            hiccup.append(["a", {"rel": class_pred}, _data["labels"].get(class_obj, class_obj)])
 
         return hiccup
 
@@ -794,14 +756,10 @@ def row2o(_stanza, _data, _uber_row):
 
     if not isinstance(uber_obj, str):
         if _uber_row["value"]:
-            LOGGER.debug(
-                "Rendering non-string object with value: {}".format(_uber_row["value"])
-            )
+            LOGGER.debug("Rendering non-string object with value: {}".format(_uber_row["value"]))
             return ["span", {"property": uber_pred}, _uber_row["value"]]
         else:
-            LOGGER.error(
-                "Received non-string object with null value; returning empty div"
-            )
+            LOGGER.error("Received non-string object with null value; returning empty div")
             return ["div"]
     elif uber_obj.startswith("<"):
         LOGGER.debug(f"Rendering literal IRI: {uber_obj}")
@@ -813,9 +771,7 @@ def row2o(_stanza, _data, _uber_row):
         inner_rows = [row for row in _stanza if row["subject"] == uber_obj]
         object_type = [row for row in inner_rows if row["predicate"] == "rdf:type"]
         if len(object_type) != 1:
-            LOGGER.warning(
-                f"Wrong number of object types found for {uber_obj}: {object_type}"
-            )
+            LOGGER.warning(f"Wrong number of object types found for {uber_obj}: {object_type}")
         object_type = object_type[0]["object"] if len(object_type) > 0 else None
 
         if object_type == "owl:Class":
@@ -828,9 +784,7 @@ def row2o(_stanza, _data, _uber_row):
             if not object_type:
                 LOGGER.warning(f"Could not determine object type for {uber_pred}")
             else:
-                LOGGER.warning(
-                    f"Unrecognised object type: {object_type} for predicate {uber_pred}"
-                )
+                LOGGER.warning(f"Unrecognised object type: {object_type} for predicate {uber_pred}")
             return ["span", {"property": uber_pred}, uber_obj]
     else:
         LOGGER.debug(

--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -32,7 +32,7 @@ OWL_PREFIX = "http://www.w3.org/2002/07/owl#{}"
 def main():
     p = ArgumentParser("tree.py", description="create an HTML page to display an ontology term")
     p.add_argument("db", help="SQLite database")
-    p.add_argument("term", help="CURIE of ontology term to display", nargs="*")
+    p.add_argument("term", help="CURIE of ontology term to display", nargs="?")
     p.add_argument(
         "-i",
         "--include-db",
@@ -43,7 +43,7 @@ def main():
 
     treename = os.path.splitext(os.path.basename(args.db))[0]
     if args.term:
-        term = args.term
+        term = [args.term]
     else:
         term = None
 
@@ -645,10 +645,10 @@ def row2o(_stanza, _data, _uber_row):
         target_row = [
             row for row in given_rows if row["predicate"] not in ("rdf:type", "owl:onProperty")
         ]
-        """for rowset in [rdf_type_row, property_row, target_row]:
+        for rowset in [rdf_type_row, property_row, target_row]:
             if len(rowset) != 1:
                 LOGGER.error(f"Rows: {given_rows} do not represent a valid restriction")
-                return ["div"]"""
+                return ["div"]
 
         property_row = property_row[0]
         target_row = target_row[0]
@@ -678,7 +678,7 @@ def row2o(_stanza, _data, _uber_row):
 
         return [
             "span",
-            ["span", {"rel": rdf_type_row["predicate"], "resource": rdf_type_row["object"]},],
+            ["span", {"rel": rdf_type_row["predicate"], "resource": rdf_type_row["object"]}],
             [
                 "a",
                 {"rel": property_row["predicate"], "resource": property_row["object"]},
@@ -699,13 +699,6 @@ def row2o(_stanza, _data, _uber_row):
         class_row = [row for row in given_rows if row["predicate"].startswith("owl:")]
         LOGGER.debug(f"Found rows: {rdf_type_row}, {class_row}")
 
-        """for rowset in [rdf_type_row, class_row]:
-            if len(rowset) != 1:
-                LOGGER.error(
-                    f"Rows: [{rdf_type_row}, {class_row}] do not represent a valid restriction"
-                )
-                return ["div"]"""
-
         rdf_type_row = rdf_type_row[0]
         class_row = class_row[0]
         class_subj = class_row["subject"]
@@ -717,7 +710,7 @@ def row2o(_stanza, _data, _uber_row):
 
         hiccup = [
             "span",
-            ["span", {"rel": rdf_type_row["predicate"], "resource": rdf_type_row["object"]},],
+            ["span", {"rel": rdf_type_row["predicate"], "resource": rdf_type_row["object"]}],
         ]
 
         # If `rel` is given, insert the attribute into the second position of the hiccup:

--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -402,6 +402,18 @@ def thing2rdfa(cur, all_prefixes, treename, include_db=False):
     add_children = [x["subject"] for x in res if x["subject"] != "owl:Thing"]
     cur.execute(f"SELECT * FROM statements WHERE stanza = 'owl:Thing'")
     stanza = cur.fetchall()
+    if not stanza:
+        stanza = [
+            {
+                "stanza": "owl:Thing",
+                "subject": "owl:Thing",
+                "predicate": "rdf:type",
+                "object": "owl:Class",
+                "value": None,
+                "datatype": None,
+                "language": None,
+            }
+        ]
     return term2rdfa(
         cur,
         all_prefixes,


### PR DESCRIPTION
Resolves #21

Added features:
* Run `tree.py` without a term arg to display the top-level under `owl:Thing`
* Add `-i`/`--include-db` flag for putting a `db` param in the query string

Fixed bugs:
* Insert the correct ID in the CURIE href for the tree parents
* Do not fail if a term has no `rdfs:label` (display CURIE as the label)
* Fix Manchester rendering for restrictions within restrictions (e.g. `realizes some concretizes some 'plan specification'` failed to render)

I also ran `black` over the code, which caused a lot of formatting changes so I apologize for the diff.