### PR TITLE
Fix multiple axiom annotations

### DIFF
--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -6,6 +6,7 @@ import sqlite3
 import sys
 
 import json
+import warnings
 
 from argparse import ArgumentParser
 from collections import defaultdict
@@ -343,9 +344,8 @@ def term2rdfa(cur, prefixes, treename, stanza, term_id, include_db=False, add_ch
     # The subjects in the stanza that are of type owl:Axiom:
     annotation_bnodes = set()
     for row in stanza:
-        subject = row["subject"]
-        if subject.startswith("_:"):
-            annotation_bnodes.add(subject)
+        if row["predicate"] == "owl:annotatedSource":
+            annotation_bnodes.add(row["subject"])
 
     # Annotations, etc. on the right-hand side for the subjects contained in
     # annotation_bnodes:
@@ -354,12 +354,10 @@ def term2rdfa(cur, prefixes, treename, stanza, term_id, include_db=False, add_ch
         subject = row["subject"]
         if subject not in annotation_bnodes:
             continue
-
         if subject in annotations:
             details = annotations[subject]
         else:
             details = {}
-
         predicate = row["predicate"]
         obj = row["object"]
         value = row["value"]
@@ -376,7 +374,6 @@ def term2rdfa(cur, prefixes, treename, stanza, term_id, include_db=False, add_ch
                 details["target_value"] = value
         else:
             details["annotation"] = row
-
         annotations[subject] = details
 
     spv2annotation = {}

--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -5,9 +5,6 @@ import os
 import sqlite3
 import sys
 
-import json
-import warnings
-
 from argparse import ArgumentParser
 from collections import defaultdict
 from gizmos.hiccup import curie2href, render
@@ -1129,15 +1126,6 @@ def row2o(_stanza, _data, _uber_row):
             f"Rendering non-blank triple: <s,p,o> = <{uber_subj}, {uber_pred}, {uber_obj}>"
         )
         return renderNonBlank(_uber_row)
-
-
-def row2po(stanza, data, row, db):
-    """Convert a predicate and object/value from a sqlite query result row to hiccup-style HTML."""
-    predicate = row["predicate"]
-    predicate_label = data["labels"].get(predicate, predicate)
-    p = ["b", ["a", {"href": curie2href(predicate, db)}, predicate_label]]
-    o = row2o(stanza, data, row)
-    return [p, o]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #35 

We needed to allow blank nodes in `row2o`. Before, if a blank subject was passed, it would just return `["div"]`, which is why we were seeing all those weird div tags.