### PR TITLE
Fix extracting with no annotations

### DIFF
--- a/gizmos/extract.py
+++ b/gizmos/extract.py
@@ -112,7 +112,7 @@ def extract_terms(database, terms, annotations, no_hierarchy=False):
             # Insert all annotations
             cur.execute(
                 """
-                    INSERT INTO tmp.predicates
+                    INSERT OR IGNORE INTO tmp.predicates
                     SELECT DISTINCT subject
                     FROM statements
                     WHERE predicate = 'rdf:type' AND object = 'owl:AnnotationProperty'"""

--- a/gizmos/extract.py
+++ b/gizmos/extract.py
@@ -104,9 +104,19 @@ def extract_terms(database, terms, annotations, no_hierarchy=False):
 
         cur.execute("CREATE TABLE tmp.predicates(predicate TEXT PRIMARY KEY NOT NULL)")
         cur.execute("INSERT INTO tmp.predicates VALUES ('rdf:type')")
-        cur.executemany(
-            "INSERT OR IGNORE INTO tmp.predicates VALUES (?)", [(x,) for x in annotations]
-        )
+        if annotations:
+            cur.executemany(
+                "INSERT OR IGNORE INTO tmp.predicates VALUES (?)", [(x,) for x in annotations]
+            )
+        else:
+            # Insert all annotations
+            cur.execute(
+                """
+                    INSERT INTO tmp.predicates
+                    SELECT DISTINCT subject
+                    FROM statements
+                    WHERE predicate = 'rdf:type' AND object = 'owl:AnnotationProperty'"""
+            )
         if not no_hierarchy:
             cur.execute(
                 """


### PR DESCRIPTION
Running `gizmos.extract` without specifying annotations results in an error:
```
Traceback (most recent call last):
  File "/opt/anaconda3/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/anaconda3/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/opt/anaconda3/lib/python3.7/site-packages/gizmos/extract.py", line 200, in <module>
    main()
  File "/opt/anaconda3/lib/python3.7/site-packages/gizmos/extract.py", line 50, in main
    sys.stdout.write(extract(args))
  File "/opt/anaconda3/lib/python3.7/site-packages/gizmos/extract.py", line 77, in extract
    extract_terms(args.database, terms, annotations, no_hierarchy=args.no_hierarchy)
  File "/opt/anaconda3/lib/python3.7/site-packages/gizmos/extract.py", line 108, in extract_terms
    "INSERT OR IGNORE INTO tmp.predicates VALUES (?)", [(x,) for x in annotations]
TypeError: 'NoneType' object is not iterable
```

If neither `-a [annotation]` nor `-A [annotation_file]` is provided, all annotations should be included in the output. 

Side note: we should make a list of *required* prefixes for `gizmos.extract` to work. e.g., if you don't define `rdf` or `owl`, no annotations will end up in the output even with this fix.

Should we search the prefixes table to get the provided prefix for these namespaces in case somebody uses a different prefix (for whatever reason...)?