### PR TITLE
Escape illegal characters in QNames in extract

### DIFF
--- a/gizmos/extract.py
+++ b/gizmos/extract.py
@@ -102,7 +102,7 @@ def escape_qnames(cur):
             curie = row[keyword]
             prefix = curie.split(":")[0]
             local_id = curie.split(":")[1]
-            local_id_fixed = re.sub(r"(?<!\\)([~!$&'()*+,;=/?#@%])", "\\\1", local_id)
+            local_id_fixed = re.sub(r"(?<!\\)([~!$&'()*+,;=/?#@%])", r"\\\1", local_id)
             if local_id != local_id_fixed:
                 updates[curie] = f"{prefix}:{local_id_fixed}"
 

--- a/tests/resources/obi-extract.ttl
+++ b/tests/resources/obi-extract.ttl
@@ -14,7 +14,8 @@
 ###  http://purl.obolibrary.org/obo/BFO_0000001
 <http://purl.obolibrary.org/obo/BFO_0000001> rdf:type owl:Class ;
                                              rdfs:subClassOf owl:Thing ;
-                                             rdfs:label "entity"@en .
+                                             rdfs:label "entity"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0010000> <http://purl.obolibrary.org/obo/bfo/axiom/0000004> .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000002

--- a/tests/resources/statements.tsv
+++ b/tests/resources/statements.tsv
@@ -130,6 +130,7 @@ BFO:0000001	BFO:0000001	BFO:0000179		entity
 BFO:0000001	BFO:0000001	owl:disjointWith	oio:ObsoleteClass			
 BFO:0000001	BFO:0000001	rdfs:subClassOf	owl:Thing			
 BFO:0000001	BFO:0000001	rdf:type	owl:Class			
+BFO:0000001	BFO:0000001	IAO:0010000	obo:bfo/axiom/0000004			
 BFO:0000001	_:riog00000256	rdfs:seeAlso	<http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf>			
 BFO:0000001	_:riog00000256	rdfs:comment		per discussion with Barry Smith		
 BFO:0000001	_:riog00000256	IAO:0010000	obo:bfo/axiom/0000004			

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -5,7 +5,9 @@ from util import test_db, create_db, compare_graphs
 
 
 def test_extract(create_db):
-    ttl = "\n".join(gizmos.extract.extract_terms(test_db, ["OBI:0100046"], ["rdfs:label"],))
+    ttl = "\n".join(
+        gizmos.extract.extract_terms(test_db, ["OBI:0100046"], ["rdfs:label", "IAO:0010000"])
+    )
 
     actual = Graph()
     actual.parse(data=ttl, format="turtle")


### PR DESCRIPTION
Resolves #38 

Replaces illegal characters in local IDs with the escaped character.