### PR TITLE
Add option to pass annotations file to tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,28 @@ If you provide the `-s`/`--include-search` flag, a search bar will be included i
 
 #### Annotations
 
-When displaying the details for a term, `gizmos.tree` will display all annotations listed in alphabetical order by annotation property on the right-hand side of the window. If you want to only include a subset of annotation properites, you can pass a text file containing the annotation property IDs (one per line) in the order you want using `-a`/`--annotations`:
+When displaying a term, `gizmos.tree` will display all annotations listed in alphabetical order by annotation property on the right-hand side of the window. You can define which annotations to include with the `-a`/`--annotation` and `-A`/`--annotations` options.
+
+You can pass one or more annotation property CURIEs in the command line using `-a`/`--annotation`. These will appear in the order that you pass:
+```
+python3 -m gizmos.tree foo.db foo:123 -a rdfs:label -a rdfs:comment > bar.html
+```
+
+You can also pass a text file containing a list of annotation property CURIEs (one per line) using `-A`/`--annotations`:
 ```
 python3 -m gizmos.tree foo.db foo:123 -a annotations.txt > bar.html
 ```
 
-If you wish to order a selection of annotation properties at the beginning of the list and still include the others after the priority annotations, you can include the annotations text file and the `-A`/`--include-all-annotations` flag:
+You can specify to include the remaining annotation properties in a text file with `*`. The `*` can appear anywhere in the list, so you can choose to include certain properites last:
 ```
-python3 -m gizmos.tree foo.db foo:123 -a annotations.txt -A > bar.html
+rdfs:label
+*
+rdfs:comment
+```
+
+The `*` character also works on the command line, but must be enclosed in quotes:
+```
+python3 -m gizmos.tree foo.db foo:123 -a rdfs:label -a "*" > bar.html
 ```
 
 #### CGI Script Example

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ This can be useful when writing scripts that return trees from different databas
 
 If you provide the `-s`/`--include-search` flag, a search bar will be included in the page. This search bar uses [typeahead.js](https://twitter.github.io/typeahead.js/) and expects the output of `gizmos.search`. The URL for the fetching the data for [Bloodhound](https://github.com/twitter/typeahead.js/blob/master/doc/bloodhound.md) is `?text=[search-text]&format=json`, or `?db=[db]&text=[search-text]&format=json` if the `-d` flag is also provided. The `format=json` is provided as a flag for use in scripts. See the CGI Example below for details on implementation.
 
+#### Annotations
+
+When displaying the details for a term, `gizmos.tree` will display all annotations listed in alphabetical order by annotation property on the right-hand side of the window. If you want to only include a subset of annotation properites, you can pass a text file containing the annotation property IDs (one per line) in the order you want using `-a`/`--annotations`:
+```
+python3 -m gizmos.tree foo.db foo:123 -a annotations.txt > bar.html
+```
+
+If you wish to order a selection of annotation properties at the beginning of the list and still include the others after the priority annotations, you can include the annotations text file and the `-A`/`--include-all-annotations` flag:
+```
+python3 -m gizmos.tree foo.db foo:123 -a annotations.txt -A > bar.html
+```
+
+
 #### CGI Script Example
 
 A simple, single-database setup. Note that `foo.db` must exist.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ If you wish to order a selection of annotation properties at the beginning of th
 python3 -m gizmos.tree foo.db foo:123 -a annotations.txt -A > bar.html
 ```
 
-
 #### CGI Script Example
 
 A simple, single-database setup. Note that `foo.db` must exist.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ python3 -m gizmos.tree foo.db foo:123 -a rdfs:label -a rdfs:comment > bar.html
 
 You can also pass a text file containing a list of annotation property CURIEs (one per line) using `-A`/`--annotations`:
 ```
-python3 -m gizmos.tree foo.db foo:123 -a annotations.txt > bar.html
+python3 -m gizmos.tree foo.db foo:123 -A annotations.txt > bar.html
 ```
 
 You can specify to include the remaining annotation properties in a text file with `*`. The `*` can appear anywhere in the list, so you can choose to include certain properites last:

--- a/tests/resources/obi-tree-OBI:0000793-annotations.ttl
+++ b/tests/resources/obi-tree-OBI:0000793-annotations.ttl
@@ -1,0 +1,30 @@
+@prefix bfo: <http://purl.obolibrary.org/obo/BFO_> .
+@prefix iao: <http://purl.obolibrary.org/obo/IAO_> .
+@prefix obi: <http://purl.obolibrary.org/obo/OBI_> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+obi:0000793 a owl:Class ;
+    rdfs:label "double blind study execution" ;
+    iao:0000115 "A double blind study execution is defined as any study execution in which neither the subjects nor the investigators are informed of which study arm the subjects are part of during the portion of the trial when the subjects are being treated" ;
+    rdfs:subClassOf obi:0000822 ;
+    owl:equivalentClass [ a owl:Class ;
+            owl:intersectionOf ( obi:0000826 [ a owl:Restriction ;
+                        owl:allValuesFrom [ a owl:Class ;
+                                owl:complementOf [ a owl:Class ;
+                                        owl:unionOf ( obi:0000804 obi:0000842 ) ] ] ;
+                        owl:onProperty bfo:0000051 ] ) ] .
+
+bfo:0000001 rdfs:subClassOf owl:Thing .
+
+bfo:0000003 rdfs:subClassOf bfo:0000001 .
+
+bfo:0000015 rdfs:subClassOf bfo:0000003 .
+
+obi:0000011 rdfs:subClassOf bfo:0000015 .
+
+obi:0000822 rdfs:subClassOf obi:0000826 .
+
+obi:0000826 rdfs:subClassOf obi:0000011 .
+

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -9,11 +9,11 @@ from rdflib import Graph
 from util import test_db, create_db, compare_graphs
 
 
-def check_term(term):
+def check_term(term, annotations):
     with sqlite3.connect(test_db) as conn:
         conn.row_factory = gizmos.tree.dict_factory
         cur = conn.cursor()
-        html = gizmos.tree.terms2rdfa(cur, "obi", [term])
+        html = gizmos.tree.terms2rdfa(cur, "obi", [term], annotation_ids=annotations)
 
     # Create the DOM document element
     parser = html5lib.HTMLParser(tree=html5lib.treebuilders.getTreeBuilder("dom"))
@@ -45,12 +45,16 @@ def check_term(term):
     parse_one_node(top, actual, None, state, [])
 
     expected = Graph()
-    expected.parse(f"tests/resources/obi-tree-{term}.ttl", format="turtle")
+    if annotations:
+        expected.parse(f"tests/resources/obi-tree-{term}-annotations.ttl", format="turtle")
+    else:
+        expected.parse(f"tests/resources/obi-tree-{term}.ttl", format="turtle")
 
     compare_graphs(actual, expected)
 
 
 def test_tree(create_db):
-    check_term("OBI:0000666")
-    check_term("OBI:0000793")
-    check_term("OBI:0100046")
+    check_term("OBI:0000666", [])
+    check_term("OBI:0000793", [])
+    check_term("OBI:0000793", ["rdfs:label", "IAO:0000115"])
+    check_term("OBI:0100046", [])


### PR DESCRIPTION
Resolves #34

#### Annotations

When displaying a term, `gizmos.tree` will display all annotations listed in alphabetical order by annotation property on the right-hand side of the window. You can define which annotations to include with the `-a`/`--annotation` and `-A`/`--annotations` options.

You can pass one or more annotation property CURIEs in the command line using `-a`/`--annotation`. These will appear in the order that you pass:
```
python3 -m gizmos.tree foo.db foo:123 -a rdfs:label -a rdfs:comment > bar.html
```

You can also pass a text file containing a list of annotation property CURIEs (one per line) using `-A`/`--annotations`:
```
python3 -m gizmos.tree foo.db foo:123 -a annotations.txt > bar.html
```

You can specify to include the remaining annotation properties in a text file with `*`. The `*` can appear anywhere in the list, so you can choose to include certain properites last:
```
rdfs:label
*
rdfs:comment
```

The `*` character also works on the command line, but must be enclosed in quotes:
```
python3 -m gizmos.tree foo.db foo:123 -a rdfs:label -a "*" > bar.html
```