### PR TITLE
Add -H/--href option, use `href` in methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ python3 -m gizmos.tree [path-to-database] [term] > [output-html]
 
 The `term` should be a CURIE with a prefix already defined in the `prefix` table of the database. If the `term` is not included, the output will show a tree starting at `owl:Thing`.
 
-The links in the tree return query strings with the ID of the term:
+This can be useful when writing scripts that return trees from different databases.
+
+If you provide the `-s`/`--include-search` flag, a search bar will be included in the page. This search bar uses [typeahead.js](https://twitter.github.io/typeahead.js/) and expects the output of `gizmos.search`. The URL for the fetching the data for [Bloodhound](https://github.com/twitter/typeahead.js/blob/master/doc/bloodhound.md) is `?text=[search-text]&format=json`, or `?db=[db]&text=[search-text]&format=json` if the `-d` flag is also provided. The `format=json` is provided as a flag for use in scripts. See the CGI Example below for details on implementation.
+
+#### Tree Links
+
+The links in the tree return query strings with the ID of the term to browse all the terms in the tree:
 ```
 ?id=FOO:123
 ```
@@ -34,13 +40,13 @@ If you provide the `-d`/`--include-db` flag, you will also get the `db` paramete
 ?db=bar&id=FOO:123
 ```
 
-This can be useful when writing scripts that return trees from different databases.
+Alternatively, if your script expects a different format than query strings (or different parameter names), you can use the `-H`/`--href` option and pass a python-esqe formatting string, e.g. `-H "./{curie}"` or `-H "?curie={curie}"`. When you click on the `FOO:123` term, the link will direct to `./FOO:123` or `?curie=FOO:123`, respectively, instead of `?id=FOO:123`.
 
-If you provide the `-s`/`--include-search` flag, a search bar will be included in the page. This search bar uses [typeahead.js](https://twitter.github.io/typeahead.js/) and expects the output of `gizmos.search`. The URL for the fetching the data for [Bloodhound](https://github.com/twitter/typeahead.js/blob/master/doc/bloodhound.md) is `?text=[search-text]&format=json`, or `?db=[db]&text=[search-text]&format=json` if the `-d` flag is also provided. The `format=json` is provided as a flag for use in scripts. See the CGI Example below for details on implementation.
+The formatting string must contain `{curie}`, and optionally contain `{db}`. Any other text enclosed in curly brackets will be ignored. This should not be used with the `-d` flag.
 
 #### Annotations
 
-When displaying a term, `gizmos.tree` will display all annotations listed in alphabetical order by annotation property on the right-hand side of the window. You can define which annotations to include with the `-a`/`--annotation` and `-A`/`--annotations` options.
+When displaying a ter, `gizmos.tree` will display all annotations listed in alphabetical order by annotation property on the right-hand side of the window. You can define which annotations to include with the `-a`/`--annotation` and `-A`/`--annotations` options.
 
 You can pass one or more annotation property CURIEs in the command line using `-a`/`--annotation`. These will appear in the order that you pass:
 ```

--- a/gizmos/hiccup.py
+++ b/gizmos/hiccup.py
@@ -1,6 +1,3 @@
-import logging
-
-
 def render(prefixes, element, href="?id={curie}", db=None, depth=0):
     """Render hiccup-style HTML vector as HTML."""
     indent = "  " * depth

--- a/gizmos/hiccup.py
+++ b/gizmos/hiccup.py
@@ -1,11 +1,7 @@
-def curie2href(curie, db=None):
-    """Convert a CURIE to an HREF"""
-    if db:
-        return f"?db={db}&id={curie}".replace("#", "%23")
-    return f"?id={curie}".replace("#", "%23")
+import logging
 
 
-def render(prefixes, element, db=None, depth=0):
+def render(prefixes, element, href="?id={curie}", db=None, depth=0):
     """Render hiccup-style HTML vector as HTML."""
     indent = "  " * depth
     if not isinstance(element, list):
@@ -20,7 +16,7 @@ def render(prefixes, element, db=None, depth=0):
     if len(element) > 0 and isinstance(element[0], dict):
         attrs = element.pop(0)
         if tag == "a" and "href" not in attrs and "resource" in attrs:
-            attrs["href"] = curie2href(attrs["resource"], db)
+            attrs["href"] = href.format(curie=attrs["resource"], db=db)
         for key, value in attrs.items():
             if key in ["checked"]:
                 if value:
@@ -39,7 +35,7 @@ def render(prefixes, element, db=None, depth=0):
                 output += child
             elif isinstance(child, list):
                 try:
-                    output += "\n" + render(prefixes, child, db=db, depth=depth + 1)
+                    output += "\n" + render(prefixes, child, href=href, db=db, depth=depth + 1)
                     spacing = f"\n{indent}"
                 except Exception as e:
                     raise Exception(f"Bad child in '{element}'", e)

--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -5,8 +5,6 @@ import os
 import sqlite3
 import sys
 
-import json
-
 from argparse import ArgumentParser
 from collections import defaultdict
 from gizmos.hiccup import render


### PR DESCRIPTION
Resolves #42 
Instead of using "prefix", I went with formatting strings because I think that will be a little more flexible. Let me know if this doesn't work for you.

---

#### Tree Links

The links in the tree return query strings with the ID of the term to browse all the terms in the tree:
```
?id=FOO:123
```

If you provide the `-d`/`--include-db` flag, you will also get the `db` parameter in the query string. The value of this parameter is the base name of the database file.
```
?db=bar&id=FOO:123
```

Alternatively, if your script expects a different format than query strings (or different parameter names), you can use the `-H`/`--href` option and pass a python-esqe formatting string, e.g. `-H "./{curie}"` or `-H "?curie={curie}"`. When you click on the `FOO:123` term, the link will direct to `./FOO:123` or `?curie=FOO:123`, respectively, instead of `?id=FOO:123`.

The formatting string must contain `{curie}`, and optionally contain `{db}`. Any other text enclosed in curly brackets will be ignored. This should not be used with the `-d` flag.