### PR TITLE
Add better support for extracting properties

### DIFF
--- a/gizmos/extract.py
+++ b/gizmos/extract.py
@@ -157,7 +157,14 @@ def extract_terms(database, terms, predicate_ids, no_hierarchy=False):
             """UPDATE tmp.terms
             SET type = (SELECT object FROM statements
                         WHERE statements.subject = terms.parent AND predicate = 'rdf:type')
-            WHERE EXISTS (SELECT * FROM statements WHERE statements.subject = terms.parent)
+            WHERE EXISTS (SELECT * FROM statements WHERE statements.subject = terms.parent)""")
+
+        # Get remaining types for undeclared classes used in subclass statements (e.g. owl:Thing)
+        cur.execute(
+            """UPDATE tmp.terms
+            SET type = 'owl:Class'
+            WHERE type IS NULL
+             AND parent IN (SELECT object FROM statements WHERE predicate = 'rdfs:subClassOf')
             """
         )
 

--- a/gizmos/extract.py
+++ b/gizmos/extract.py
@@ -116,10 +116,11 @@ def extract_terms(database, terms, predicate_ids, no_hierarchy=False):
 
         cur.execute("ATTACH DATABASE '' AS tmp")
 
-        # Create the extract table
+        # Create the terms table containing parent -> child relationships
         cur.execute("CREATE TABLE tmp.terms(parent TEXT NOT NULL, child TEXT)")
         cur.executemany("INSERT INTO tmp.terms VALUES (?, NULL)", [(x,) for x in terms])
 
+        # Create tmp predicates table
         cur.execute("CREATE TABLE tmp.predicates(predicate TEXT PRIMARY KEY NOT NULL)")
         cur.execute("INSERT INTO tmp.predicates VALUES ('rdf:type')")
         if predicate_ids:
@@ -129,26 +130,40 @@ def extract_terms(database, terms, predicate_ids, no_hierarchy=False):
         else:
             # Insert all predicates
             cur.execute(
-                """
-                    INSERT OR IGNORE INTO tmp.predicates
-                    SELECT DISTINCT predicate
-                    FROM statements"""
+                """INSERT OR IGNORE INTO tmp.predicates
+                SELECT DISTINCT predicate
+                FROM statements WHERE predicate NOT IN ('rdfs:subClassOf', 'rdfs:subPropertyOf')"""
             )
+
         if not no_hierarchy:
+            # Add subclasses & subproperties
             cur.execute(
-                """
-                  WITH RECURSIVE ancestors(parent, child) AS (
+                """WITH RECURSIVE ancestors(parent, child) AS (
                     SELECT * FROM terms
                     UNION
                     SELECT object AS parent, subject AS child
                     FROM statements, ancestors
                     WHERE ancestors.parent = statements.stanza
-                      AND statements.predicate = 'rdfs:subClassOf'
+                      AND statements.predicate IN ('rdfs:subClassOf', 'rdfs:subPropertyOf')
                       AND statements.object NOT LIKE '_:%'
                   )
                   INSERT INTO tmp.terms
                   SELECT parent, child FROM ancestors"""
             )
+
+        # Add entity type to terms table
+        cur.execute("ALTER TABLE tmp.terms ADD COLUMN type")
+        cur.execute(
+            """UPDATE tmp.terms
+            SET type = (SELECT object FROM statements
+                        WHERE statements.subject = terms.parent AND predicate = 'rdf:type')
+            WHERE EXISTS (SELECT * FROM statements WHERE statements.subject = terms.parent)
+            """
+        )
+
+        cur.execute("SELECT * FROM tmp.terms")
+        for row in cur.fetchall():
+            logging.error(row)
 
         cur.execute(
             """CREATE TABLE tmp.extract(
@@ -161,19 +176,56 @@ def extract_terms(database, terms, predicate_ids, no_hierarchy=False):
                  language TEXT
                )"""
         )
+
+        # Insert rdf:type declarations
         cur.execute(
-            """
-                INSERT INTO tmp.extract (stanza, subject, predicate, object)
-                SELECT DISTINCT child, child, 'rdfs:subClassOf', parent
-                FROM terms WHERE child IS NOT NULL"""
+            """INSERT INTO tmp.extract
+            SELECT * FROM statements
+            WHERE subject IN (SELECT DISTINCT parent FROM terms) AND predicate = 'rdf:type'"""
+        )
+
+        # Insert subclass & subproperty statements
+        cur.execute(
+            """INSERT INTO tmp.extract (stanza, subject, predicate, object)
+            SELECT DISTINCT child, child, 'rdfs:subClassOf', parent
+            FROM terms WHERE child IS NOT NULL AND type = 'owl:Class'"""
         )
         cur.execute(
-            """
-                INSERT INTO tmp.extract
-                SELECT *
-                FROM statements
-                WHERE subject IN (SELECT DISTINCT parent FROM terms)
-                  AND predicate IN (SELECT predicate FROM predicates)"""
+            """INSERT INTO tmp.extract (stanza, subject, predicate, object)
+            SELECT DISTINCT child, child, 'rdfs:subPropertyOf', parent
+            FROM terms WHERE child IS NOT NULL
+             AND type IN ('owl:AnnotationProperty', 'owl:DataProperty', 'owl:ObjectProperty')"""
+        )
+
+        # Insert literal annotations
+        cur.execute(
+            """INSERT INTO tmp.extract
+            SELECT *
+            FROM statements
+            WHERE subject IN (SELECT DISTINCT parent FROM terms)
+              AND predicate IN (SELECT predicate FROM predicates)
+              AND value IS NOT NULL"""
+        )
+
+        # Insert logical relationships (object must be in set of input terms)
+        cur.execute(
+            """INSERT INTO tmp.extract
+            SELECT * FROM statements
+            WHERE subject IN (SELECT DISTINCT parent FROM terms)
+              AND predicate IN (SELECT predicate FROM predicates)
+              AND object IN (SELECT DISTINCT parent FROM terms)"""
+        )
+
+        # Insert IRI annotations (object does not have to be in input terms)
+        cur.execute(
+            """INSERT INTO tmp.extract (stanza, subject, predicate, object)
+            SELECT s1.stanza, s1.subject, s1.predicate, s1.object
+            FROM statements s1
+            JOIN statements s2 ON s1.predicate = s2.subject
+            WHERE s1.subject IN (SELECT DISTINCT parent FROM terms)
+              AND s1.predicate IN (SELECT predicate FROM predicates)
+              AND s2.predicate = 'rdf:type' AND s2.value = 'owl:AnnotationProperty'
+              AND s1.object IS NOT NULL"""
         )
 
         # Create esc function

--- a/gizmos/extract.py
+++ b/gizmos/extract.py
@@ -161,10 +161,6 @@ def extract_terms(database, terms, predicate_ids, no_hierarchy=False):
             """
         )
 
-        cur.execute("SELECT * FROM tmp.terms")
-        for row in cur.fetchall():
-            logging.error(row)
-
         cur.execute(
             """CREATE TABLE tmp.extract(
                  stanza TEXT,
@@ -224,8 +220,8 @@ def extract_terms(database, terms, predicate_ids, no_hierarchy=False):
             JOIN statements s2 ON s1.predicate = s2.subject
             WHERE s1.subject IN (SELECT DISTINCT parent FROM terms)
               AND s1.predicate IN (SELECT predicate FROM predicates)
-              AND s2.predicate = 'rdf:type' AND s2.value = 'owl:AnnotationProperty'
-              AND s1.object IS NOT NULL"""
+              AND s2.object = 'owl:AnnotationProperty'
+              AND s1.object NOT NULL"""
         )
 
         # Create esc function

--- a/tests/resources/obi-extract.ttl
+++ b/tests/resources/obi-extract.ttl
@@ -13,7 +13,6 @@
 
 ###  http://purl.obolibrary.org/obo/BFO_0000001
 <http://purl.obolibrary.org/obo/BFO_0000001> rdf:type owl:Class ;
-                                             rdfs:subClassOf owl:Thing ;
                                              rdfs:label "entity"@en ;
                                              <http://purl.obolibrary.org/obo/IAO_0010000> <http://purl.obolibrary.org/obo/bfo/axiom/0000004> .
 

--- a/tests/resources/obi-extract.ttl
+++ b/tests/resources/obi-extract.ttl
@@ -13,6 +13,7 @@
 
 ###  http://purl.obolibrary.org/obo/BFO_0000001
 <http://purl.obolibrary.org/obo/BFO_0000001> rdf:type owl:Class ;
+                                             rdfs:subClassOf owl:Thing ;
                                              rdfs:label "entity"@en ;
                                              <http://purl.obolibrary.org/obo/IAO_0010000> <http://purl.obolibrary.org/obo/bfo/axiom/0000004> .
 

--- a/tests/resources/statements.tsv
+++ b/tests/resources/statements.tsv
@@ -65,6 +65,7 @@ IAO:0000232	IAO:0000232	IAO:0000115		An administrative note of use for a curator
 IAO:0000232	IAO:0000232	IAO:0000114	IAO:0000122			
 IAO:0000232	IAO:0000232	IAO:0000111		curator note		en
 IAO:0000232	IAO:0000232	rdf:type	owl:AnnotationProperty			
+IAO:0010000	IAO:0010000	rdf:type	owl:AnnotationProperty			
 BFO:0000051	BFO:0000051	rdfs:label		has part		en
 BFO:0000051	BFO:0000051	obo:RO_0001900	obo:RO_0001901			
 BFO:0000051	BFO:0000051	IAO:0000118		has_part		en


### PR DESCRIPTION
While working on MRO export files, I ran into a weird output when I extracted from RO. The object properties were both object properties and individuals, and unwanted terms got pulled in as dangling nodes when I didn't specify which predicates I wanted OR if the value of a triple was just an unwanted term.

The first fix is to add better support for extracting properties and their hierarchies. It adds both `rdfs:subClassOf` and `rdfs:subPropertyOf` relationships to the terms table.

The second fix splits up inserting predicates into the extract table into the following steps:
1. Insert `rdf:type` declarations
2. Insert subclass & subproperty statements based on relationships in the terms table
3. Insert literal annotations (subject is in our extract terms and `value` isn't null)
4. Insert logical relationships (subject and object are in our extract terms, otherwise we get extra terms in this step)
5. Insert IRI annotations (object doesn't have to be in our extract terms, predicate is always annotation property)