### PR TITLE
Handle multiple parents in tree

### DIFF
--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -395,6 +395,15 @@ def build_tree(
             console.log("DONE");
         }
         $('#more').hide();
+    }
+    
+    function show_siblings() {
+        document.getElementById('siblings').style.display='none';
+        var x = document.getElementsByClassName('sibling');
+        var i;
+        for (i = 0; i < x.length; i++) {
+            x[i].style.display='block';
+        }
     }"""
 
     # Custom JS for search bar using Typeahead
@@ -511,14 +520,7 @@ def build_tree(
                     "content": "width=device-width, initial-scale=1, shrink-to-fit=no",
                 },
             ],
-            [
-                "link",
-                {
-                    "rel": "stylesheet",
-                    "href": bootstrap_css,
-                    "crossorigin": "anonymous",
-                },
-            ],
+            ["link", {"rel": "stylesheet", "href": bootstrap_css, "crossorigin": "anonymous",},],
             ["link", {"rel": "stylesheet", "href": "../style.css"}],
             ["title", title],
             [
@@ -705,6 +707,9 @@ def get_entity_type(cur, term_id):
     )
     res = cur.fetchall()
     if len(res) > 1:
+        for r in res:
+            if r["object"] in top_levels:
+                return r["object"]
         return "owl:Individual"
     elif len(res) == 1:
         entity_type = res[0]["object"]
@@ -743,8 +748,16 @@ def get_hierarchy(cur, term_id, entity_type, add_children=None):
         res = cur.fetchall()
     else:
         pred = "rdfs:subPropertyOf"
+        add_query = ""
         if entity_type == "owl:Class":
             pred = "rdfs:subClassOf"
+            add_query = f"""UNION
+                        SELECT '{entity_type}' AS parent, subject AS child
+                        FROM statements
+                        WHERE predicate = '{pred}'
+                          AND object = 'owl:Thing'
+                          AND subject NOT LIKE '_:%'
+                        """
         cur.execute(
             f"""WITH RECURSIVE ancestors(parent, child) AS (
                 VALUES ('{term_id}', NULL)
@@ -754,6 +767,23 @@ def get_hierarchy(cur, term_id, entity_type, add_children=None):
                 FROM statements
                 WHERE predicate = '{pred}'
                   AND object = '{term_id}'
+                UNION
+                --- The children of the parents of the current term
+                SELECT s2.object AS parent, s2.subject AS child
+                FROM statements s1
+                JOIN statements s2 ON s1.object = s2.object
+                WHERE s1.predicate = '{pred}'
+                  AND s1.subject = '{term_id}'
+                  AND s2.predicate = '{pred}'
+                UNION
+                SELECT '{entity_type}' AS parent, subject AS child
+                FROM statements
+                WHERE subject NOT LIKE '_:%'
+                  AND subject IS NOT 'owl:Thing'
+                  AND subject NOT IN
+                    (SELECT subject FROM statements WHERE predicate = '{pred}')
+                  AND object = '{entity_type}'
+                {add_query}
                 UNION
                 -- The non-blank parents of all of the parent terms extracted so far:
                 SELECT object AS parent, subject AS child
@@ -866,9 +896,7 @@ def get_ontology(cur, prefixes):
     for prefix, base in prefixes:
         if base == "http://purl.org/dc/terms/":
             dct = f"{prefix}:title"
-    cur.execute(
-        f"SELECT value FROM statements WHERE subject = '{iri}' AND predicate = '{dct}'"
-    )
+    cur.execute(f"SELECT value FROM statements WHERE subject = '{iri}' AND predicate = '{dct}'")
     res = cur.fetchone()
     if not res:
         return iri, None
@@ -1036,7 +1064,9 @@ def term2rdfa(
     if not title:
         title = treename + " Browser"
 
-    if (term_id in top_levels and term_id != "ontology") or (term_id == "ontology" and not ontology_iri):
+    if (term_id in top_levels and term_id != "ontology") or (
+        term_id == "ontology" and not ontology_iri
+    ):
         si = None
         if ontology_iri:
             si = ontology_iri
@@ -1085,6 +1115,83 @@ def term2rdfa(
     return ps, term
 
 
+def parent2tree(data, treename, selected_term, selected_children, node, href="?id={curie}"):
+    """Return a hiccup-style HTML vector of the full hierarchy for a parent node."""
+    # Sort siblings by labels
+    siblings = data[treename][node]["children"]
+    sib_map = {}
+    for s in siblings:
+        label = data["labels"].get(s, s)
+        sib_map[label] = s
+    sib_keys = sorted(sib_map.keys())
+
+    # Then add them to the hierarchy (hidden)
+    cur_hierarchy = ["ul"]
+    for k in sib_keys:
+        s = sib_map[k]
+        if s == selected_term:
+            selected = ["li", tree_label(data, treename, selected_term)]
+            if len(siblings) > 1:
+                selected.append(
+                    [
+                        "a",
+                        {"id": "siblings", "href": "javascript:show_siblings()"},
+                        "[show siblings]",
+                    ]
+                )
+            selected.append(selected_children)
+            cur_hierarchy.append(selected)
+            continue
+        o = ["a", {"href": href.format(curie=s, db=treename)}, tree_label(data, treename, s)]
+        cur_hierarchy.append(["li", {"class": "sibling", "style": "display: none;"}, o])
+
+    if node in top_levels:
+        # Parent is top-level, nothing to add
+        return cur_hierarchy
+
+    # Add parents to the hierarchy
+    i = 0
+    while node and i < 100:
+        i += 1
+        oc = node
+        object_label = tree_label(data, treename, node)
+        parents = data[treename][node]["parents"]
+        if len(parents) == 0:
+            # No parent
+            o = [
+                "a",
+                {"resource": oc, "href": href.format(curie=node, db=treename)},
+                object_label,
+            ]
+            cur_hierarchy = ["ul", ["li", o, cur_hierarchy]]
+            break
+        parent = parents[0]
+        if node == parent:
+            # Parent is the same
+            o = [
+                "a",
+                {"resource": oc, "href": href.format(curie=node, db=treename)},
+                object_label,
+            ]
+            cur_hierarchy = ["ul", ["li", o, cur_hierarchy]]
+            break
+        o = [
+            "a",
+            {
+                "about": parent,
+                "rev": "rdfs:subClassOf",
+                "resource": oc,
+                "href": href.format(curie=node, db=treename),
+            },
+            object_label,
+        ]
+        cur_hierarchy = ["ul", ["li", o, cur_hierarchy]]
+        node = parent
+        if node in top_levels:
+            break
+    return cur_hierarchy
+
+
 def term2tree(data, treename, term_id, entity_type, href="?id={curie}", max_children=100):
     """Create a hiccup-style HTML hierarchy vector for the given term."""
     if treename not in data or term_id not in data[treename]:
@@ -1117,13 +1224,14 @@ def term2tree(data, treename, term_id, entity_type, href="?id={curie}", max_chil
             continue
         oc = child
         object_label = tree_label(data, treename, oc)
-        if child in obsolete:
-            object_label = ["s", object_label]
         o = ["a", {"rev": predicate, "resource": oc}, object_label]
         attrs = {}
         if len(children) > max_children:
             attrs["style"] = "display: none"
-        children.append(["li", attrs, o])
+        if attrs:
+            children.append(["li", attrs, o])
+        else:
+            children.append(["li", o])
         if len(children) == max_children:
             total = len(term_tree["children"])
             attrs = {"href": "javascript:show_children()"}
@@ -1132,79 +1240,44 @@ def term2tree(data, treename, term_id, entity_type, href="?id={curie}", max_chil
     if len(children) == 0:
         children = ""
     term_label = tree_label(data, treename, term_id)
-    if term_id in obsolete:
-        term_label = ["s", term_label]
 
     # Get the parents for our target term
-    hierarchy = ["ul", ["li", term_label, children]]
-    i = 0
     parents = term_tree["parents"]
     if parents:
-        node = parents[0]
-        while node and i < 100:
-            i += 1
-            oc = node
-            object_label = tree_label(data, treename, node)
-            if node in obsolete:
-                object_label = ["s", object_label]
-            parents = data[treename][node]["parents"]
-            if len(parents) == 0:
-                # No parent
-                o = [
-                    "a",
-                    {"resource": oc, "href": href.format(curie=node, db=treename)},
-                    object_label,
-                ]
-                hierarchy = ["ul", ["li", o, hierarchy]]
-                break
-            parent = parents[0]
-            if node == parent:
-                # Parent is the same
-                if parent in top_levels:
-                    href_ele = {"href": href.format(curie=node, db=treename)}
-                else:
-                    href_ele = {"resource": oc, "href": href.format(curie=node, db=treename)}
-                o = [
-                    "a",
-                    href_ele,
-                    object_label,
-                ]
-                hierarchy = ["ul", ["li", o, hierarchy]]
-                break
-            if parent in top_levels:
-                href_ele = {"href": href.format(curie=node, db=treename)}
-            else:
-                href_ele = {
-                    "about": parent,
-                    "rev": "rdfs:subClassOf",
-                    "resource": oc,
-                    "href": href.format(curie=node, db=treename),
-                }
-
-            o = [
-                "a",
-                href_ele,
-                object_label,
-            ]
-            hierarchy = ["ul", ["li", o, hierarchy]]
-            node = parent
+        hierarchy = ["ul"]
+        for p in parents:
+            if p.startswith("_:"):
+                continue
+            hierarchy.append(parent2tree(data, treename, term_id, children.copy(), p, href=href))
+    else:
+        hierarchy = ["ul", ["li", term_label, children]]
 
     i = 0
     hierarchies = ["ul", {"id": f"hierarchy", "class": "hierarchy multiple-children col-md"}]
     for t, object_label in top_levels.items():
-        if t == entity_type:
-            hierarchies.append(hierarchy)
-            continue
         o = ["a", {"href": href.format(curie=t, db=treename)}, object_label]
+        if t == entity_type:
+            if term_id == entity_type:
+                hierarchies.append(hierarchy)
+            else:
+                hierarchies.append(["ul", ["li", o, hierarchy]])
+            continue
         hierarchies.append(["ul", ["li", o]])
         i += 1
+
+    import json
+
+    print(json.dumps(hierarchies, indent=4))
     return hierarchies
 
 
 def tree_label(data, treename, s):
     """Retrieve the label of a term."""
     node = data[treename][s]
-    return node.get("label", s)
+    label = node.get("label", s)
+    if s in data["obsolete"]:
+        return ["s", label]
+    return label
 
 
 def row2o(_stanza, _data, _uber_row):

--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -1264,10 +1264,6 @@ def term2tree(data, treename, term_id, entity_type, href="?id={curie}", max_chil
             continue
         hierarchies.append(["ul", ["li", o]])
         i += 1
-
-    import json
-
-    print(json.dumps(hierarchies, indent=4))
     return hierarchies
 
 

--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -1167,10 +1167,7 @@ def term2tree(data, treename, term_id, entity_type, href="?id={curie}", max_chil
         attrs = {}
         if len(children) > max_children:
             attrs["style"] = "display: none"
-        if attrs:
-            children.append(["li", attrs, o])
-        else:
-            children.append(["li", o])
+        children.append(["li", attrs, o])
         if len(children) == max_children:
             total = len(term_tree["children"])
             attrs = {"href": "javascript:show_children()"}


### PR DESCRIPTION
If a term had multiple parents, it would always show up under the same node, even if you clicked it from another. Now multiple hierarchies will show up (I know this isn't correct, I just added a bunch of parents to test it out):

![image](https://user-images.githubusercontent.com/16750150/101818591-f2747f00-3ad8-11eb-82d9-8b7c4779172d.png)

A better improvement would be to remove redundancies and show up to the common ancestors, but that will take more work to add in... I'm not sure the best way to do that efficiently.