### PR TITLE
Add + next to nodes with children in tree view

### DIFF
--- a/gizmos/hiccup.py
+++ b/gizmos/hiccup.py
@@ -1,17 +1,18 @@
 def render(prefixes, element, href="?id={curie}", db=None, depth=0):
     """Render hiccup-style HTML vector as HTML."""
+    render_element = element.copy()
     indent = "  " * depth
-    if not isinstance(element, list):
+    if not isinstance(render_element, list):
         raise Exception(f"Element is not a list: {element}")
-    if len(element) == 0:
+    if len(render_element) == 0:
         raise Exception("Element is an empty list")
-    tag = element.pop(0)
+    tag = render_element.pop(0)
     if not isinstance(tag, str):
         raise Exception(f"Tag '{tag}' is not a string in '{element}'")
     output = f"{indent}<{tag}"
 
-    if len(element) > 0 and isinstance(element[0], dict):
-        attrs = element.pop(0)
+    if len(render_element) > 0 and isinstance(render_element[0], dict):
+        attrs = render_element.pop(0)
         if tag == "a" and "href" not in attrs and "resource" in attrs:
             attrs["href"] = href.format(curie=attrs["resource"], db=db)
         for key, value in attrs.items():
@@ -21,21 +22,18 @@ def render(prefixes, element, href="?id={curie}", db=None, depth=0):
             else:
                 output += f' {key}="{value}"'
 
-    if tag in ["meta", "link"]:
+    if tag in ["meta", "link", "path"]:
         output += "/>"
         return output
     output += ">"
     spacing = ""
-    if len(element) > 0:
-        for child in element:
+    if len(render_element) > 0:
+        for child in render_element:
             if isinstance(child, str):
                 output += child
             elif isinstance(child, list):
-                try:
-                    output += "\n" + render(prefixes, child, href=href, db=db, depth=depth + 1)
-                    spacing = f"\n{indent}"
-                except Exception as e:
-                    raise Exception(f"Bad child in '{element}'", e)
+                output += "\n" + render(prefixes, child, href=href, db=db, depth=depth + 1)
+                spacing = f"\n{indent}"
             else:
                 raise Exception(f"Bad type for child '{child}' in '{element}'")
     output += f"{spacing}</{tag}>"

--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -537,22 +537,6 @@ def build_tree(
             [
                 "style",
                 """
-        .plus {
-          display: inline-block;
-          width: 14px;
-          height: 14px;
-          background:
-            linear-gradient(#C0C0C0,#C0C0C0),
-            linear-gradient(#C0C0C0,#C0C0C0),
-            #fff;
-          background-position: center;
-          background-size: 50% 2px,2px 50%;
-          background-repeat: no-repeat;
-          border-width: 1px;
-          border-style: solid;
-          border-color: #C0C0C0;
-          border-radius: 50%;
-        }
         #annotations {
           padding-left: 1em;
           list-style-type: none !important;

--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -1255,7 +1255,6 @@ def tree_label(data, treename, s):
     """Retrieve the label of a term."""
     node = data[treename][s]
     label = node.get("label", s)
-    children = node.get("children")
     if s in data["obsolete"]:
         return ["s", label]
     return label


### PR DESCRIPTION
Resolves #49 

I think it only makes sense to do this for children of the target term, because we already know that all the ancestors shown have at least one child.

Let me know if this is too light and I can use a darker gray. Alternatively, we could use the same blue color as the links?

![image](https://user-images.githubusercontent.com/16750150/102133481-04705d80-3e0a-11eb-84cd-5ade49661e7d.png)

Originally I tried doing it with pure CSS as a `:after` element, but it won't let you put HTML in so we can't have the pretty circle button. If we do want to keep it pure CSS, I can just put a text `[+]` instead of the button.