### PR TITLE
Fix --values option in gizmos.export

### DIFF
--- a/gizmos/export.py
+++ b/gizmos/export.py
@@ -55,7 +55,12 @@ def main():
     )
     p.add_argument("-f", "--format", help="Output format (tsv, csv, html)", default="tsv")
     p.add_argument("-s", "--split", help="Character to split multiple values on", default="|")
-    p.add_argument("-c", "--contents-only", action="store_true", help="If provided with HTML format, render HTML without roots")
+    p.add_argument(
+        "-c",
+        "--contents-only",
+        action="store_true",
+        help="If provided with HTML format, render HTML without roots",
+    )
     p.add_argument("-V", "--values", help="Default value format for cell values", default="IRI")
     p.add_argument(
         "-n",
@@ -75,7 +80,14 @@ def export(args):
         sys.exit(1)
     predicates = get_terms(args.predicate, args.predicates)
     return export_terms(
-        args.database, terms, predicates, args.format, standalone=not args.contents_only, split=args.split, no_headers=args.no_headers
+        args.database,
+        terms,
+        predicates,
+        args.format,
+        standalone=not args.contents_only,
+        split=args.split,
+        no_headers=args.no_headers,
+        default_value_format=args.values,
     )
 
 
@@ -248,7 +260,7 @@ def get_values(cur, term, predicate_ids):
 
 def render_html(prefixes, value_formats, predicate_ids, details, standalone=True, no_headers=False):
     """Render an HTML table."""
-    predicate_labels = {v: k for k,v in predicate_ids.items()}
+    predicate_labels = {v: k for k, v in predicate_ids.items()}
     # Create the prefix element
     pref_strs = []
     for prefix, base in prefixes.items():
@@ -332,7 +344,14 @@ def render_html(prefixes, value_formats, predicate_ids, details, standalone=True
 
 
 def render_output(
-    prefixes, value_formats, predicate_ids, details, fmt, split="|", standalone=True, no_headers=False
+    prefixes,
+    value_formats,
+    predicate_ids,
+    details,
+    fmt,
+    split="|",
+    standalone=True,
+    no_headers=False,
 ):
     """Render the string output based on the format."""
     if fmt == "tsv":
@@ -340,7 +359,14 @@ def render_output(
     elif fmt == "csv":
         return render_table(value_formats, details, ",", split=split, no_headers=no_headers)
     elif fmt == "html":
-        return render_html(prefixes, value_formats, predicate_ids, details, standalone=standalone, no_headers=no_headers)
+        return render_html(
+            prefixes,
+            value_formats,
+            predicate_ids,
+            details,
+            standalone=standalone,
+            no_headers=no_headers,
+        )
     else:
         raise Exception("Invalid format: " + fmt)
 
@@ -385,7 +411,14 @@ def render_table(value_formats, details, separator, split="|", no_headers=False)
 
 
 def export_terms(
-    database, terms, predicates, fmt, split="|", standalone=True, default_value_format="IRI", no_headers=False
+    database,
+    terms,
+    predicates,
+    fmt,
+    split="|",
+    standalone=True,
+    default_value_format="IRI",
+    no_headers=False,
 ):
     """Retrieve details for given terms and render in the given format."""
 
@@ -446,7 +479,14 @@ def export_terms(
             details[term] = term_details
 
     return render_output(
-        prefixes, value_formats, predicate_ids, details, fmt, split=split, standalone=standalone, no_headers=no_headers
+        prefixes,
+        value_formats,
+        predicate_ids,
+        details,
+        fmt,
+        split=split,
+        standalone=standalone,
+        no_headers=no_headers,
     )
 
 


### PR DESCRIPTION
We have the `--values` option in the argument parser and it's documented, but including it in the command line args does nothing because it isn't passed to `export_terms`.

The `export` module was also never run through the `black` formatter, so this is also included.