### PR TITLE
Get all terms when no terms are provided in export

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ python3 -m gizmos.export -d [path-to-database] > [output-tsv]
 
 If you know the term or set of terms you wish to include in the export, you can use the `--term`/`--terms` options. The `term` (`-t` or `--term`) should be the CURIE or label of your desired term, and you can include more than one `-t` option. Mulitple terms can be specified with `-T <file>`/`--terms <file>` with each CURIE or label on one line.
 
-If a term or terms are not included, *all* terms in the database will be returned. The set of all terms returned can be filtered using the `-F`/`--filter` option (note that this option will not do anything when you are using `--term` or `--terms`). The argument to filter should be a SQL-like statement to append after the `WHERE` clause, excluding the `WHERE`. For example:
+If a term or terms are not included, *all* terms in the database will be returned. The set of all terms returned can be narrowed using the `-w`/`--where` option (note that this option will not do anything when you are using `--term` or `--terms`). The argument to `--where` should be a SQL-like statement to append after the `WHERE` clause, excluding the `WHERE`. For example:
 
 ```
-python3 -m gizmos.export -d ont.db -F "subject LIKE 'EX:%'" > out.tsv
+python3 -m gizmos.export -d ont.db -w "subject LIKE 'EX:%'" > out.tsv
 ```
 
 For information on the structure of the `statements` table, please see [RDFTab](https://github.com/ontodev/rdftab.rs).

--- a/README.md
+++ b/README.md
@@ -19,10 +19,22 @@ Each `gizmos` module uses a SQL database version of an RDF or OWL ontology to cr
 
 The `export` module creates a table (default TSV) output containing the terms and their predicates written to stdout.
 ```
-python3 -m gizmos.export -d [path-to-database] -t [term] > [output-tsv]
+python3 -m gizmos.export -d [path-to-database] > [output-tsv]
 ```
 
-The `term` should be the CURIE or label of your desired term, and you can include more than one `-t` option. Mulitple terms can also be specified with `-T <file>`/`--terms <file>` with each CURIE or label on one line. If a term or terms are not included, *all* terms in the database will be returned.
+#### Terms
+
+If you know the term or set of terms you wish to include in the export, you can use the `--term`/`--terms` options. The `term` (`-t` or `--term`) should be the CURIE or label of your desired term, and you can include more than one `-t` option. Mulitple terms can be specified with `-T <file>`/`--terms <file>` with each CURIE or label on one line.
+
+If a term or terms are not included, *all* terms in the database will be returned. The set of all terms returned can be filtered using the `-F`/`--filter` option (note that this option will not do anything when you are using `--term` or `--terms`). The argument to filter should be a SQL-like statement to append after the `WHERE` clause, excluding the `WHERE`. For example:
+
+```
+python3 -m gizmos.export -d ont.db -F "subject LIKE 'EX:%'" > out.tsv
+```
+
+For information on the structure of the `statements` table, please see [RDFTab](https://github.com/ontodev/rdftab.rs).
+
+#### Output Formats
 
 You can specify a format other than TSV by using the `-f <format>`/`--format <format>` option. The following formats are supported:
 * TSV
@@ -30,6 +42,8 @@ You can specify a format other than TSV by using the `-f <format>`/`--format <fo
 * HTML \*
 
 \* This is full HTML page. If you just want the content without `<html>` and `<body>` tags, include `-c`/`--content-only`.
+
+#### Headers and Values
 
 By default, headers are included. The headers are the predicate labels. If you wish to not include headers, include `-n`/`--no-headers`.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `export` module creates a table (default TSV) output containing the terms an
 python3 -m gizmos.export -d [path-to-database] -t [term] > [output-tsv]
 ```
 
-The `term` should be the CURIE or label of your desired term, and you can include more than one `-t` option. Mulitple terms can also be specified with `-T <file>`/`--terms <file>` with each CURIE or label on one line.
+The `term` should be the CURIE or label of your desired term, and you can include more than one `-t` option. Mulitple terms can also be specified with `-T <file>`/`--terms <file>` with each CURIE or label on one line. If a term or terms are not included, *all* terms in the database will be returned.
 
 You can specify a format other than TSV by using the `-f <format>`/`--format <format>` option. The following formats are supported:
 * TSV

--- a/gizmos/export.py
+++ b/gizmos/export.py
@@ -54,7 +54,6 @@ def main():
         "-P", "--predicates", help="File containing CURIEs or labels of predicates to include",
     )
     p.add_argument("-f", "--format", help="Output format (tsv, csv, html)", default="tsv")
-    p.add_argument("-F", "--filter", help="SQL WHERE statement to filter terms")
     p.add_argument("-s", "--split", help="Character to split multiple values on", default="|")
     p.add_argument(
         "-c",
@@ -63,6 +62,7 @@ def main():
         help="If provided with HTML format, render HTML without roots",
     )
     p.add_argument("-V", "--values", help="Default value format for cell values", default="IRI")
+    p.add_argument("-w", "--where", help="SQL WHERE statement to include when selecting terms")
     p.add_argument(
         "-n",
         "--no-headers",
@@ -82,10 +82,10 @@ def export(args):
         terms,
         predicates,
         args.format,
-        query_filter=args.filter,
         standalone=not args.contents_only,
         split=args.split,
         no_headers=args.no_headers,
+        where=args.where,
     )
 
 
@@ -413,11 +413,11 @@ def export_terms(
     terms,
     predicates,
     fmt,
-    query_filter=None,
     split="|",
     standalone=True,
     default_value_format="IRI",
     no_headers=False,
+    where=None,
 ):
     """Retrieve details for given terms and render in the given format."""
 
@@ -444,9 +444,9 @@ def export_terms(
             term_ids = get_ids(cur, terms)
         else:
             term_ids = []
-            if query_filter:
+            if where:
                 # Use provided query filter to select terms
-                query = "SELECT DISTINCT stanza FROM statements WHERE " + query_filter
+                query = "SELECT DISTINCT stanza FROM statements WHERE " + where
             else:
                 # Get all, excluding blank nodes
                 query = "SELECT DISTINCT stanza FROM statements WHERE stanza NOT LIKE '_:%'"

--- a/gizmos/export.py
+++ b/gizmos/export.py
@@ -55,7 +55,12 @@ def main():
     )
     p.add_argument("-f", "--format", help="Output format (tsv, csv, html)", default="tsv")
     p.add_argument("-s", "--split", help="Character to split multiple values on", default="|")
-    p.add_argument("-c", "--contents-only", action="store_true", help="If provided with HTML format, render HTML without roots")
+    p.add_argument(
+        "-c",
+        "--contents-only",
+        action="store_true",
+        help="If provided with HTML format, render HTML without roots",
+    )
     p.add_argument("-V", "--values", help="Default value format for cell values", default="IRI")
     p.add_argument(
         "-n",
@@ -70,12 +75,15 @@ def main():
 def export(args):
     """Wrapper for export_terms."""
     terms = get_terms(args.term, args.terms)
-    if not terms:
-        logging.critical("One or more term(s) must be specified with --term or --terms")
-        sys.exit(1)
     predicates = get_terms(args.predicate, args.predicates)
     return export_terms(
-        args.database, terms, predicates, args.format, standalone=not args.contents_only, split=args.split, no_headers=args.no_headers
+        args.database,
+        terms,
+        predicates,
+        args.format,
+        standalone=not args.contents_only,
+        split=args.split,
+        no_headers=args.no_headers,
     )
 
 
@@ -248,7 +256,7 @@ def get_values(cur, term, predicate_ids):
 
 def render_html(prefixes, value_formats, predicate_ids, details, standalone=True, no_headers=False):
     """Render an HTML table."""
-    predicate_labels = {v: k for k,v in predicate_ids.items()}
+    predicate_labels = {v: k for k, v in predicate_ids.items()}
     # Create the prefix element
     pref_strs = []
     for prefix, base in prefixes.items():
@@ -332,7 +340,14 @@ def render_html(prefixes, value_formats, predicate_ids, details, standalone=True
 
 
 def render_output(
-    prefixes, value_formats, predicate_ids, details, fmt, split="|", standalone=True, no_headers=False
+    prefixes,
+    value_formats,
+    predicate_ids,
+    details,
+    fmt,
+    split="|",
+    standalone=True,
+    no_headers=False,
 ):
     """Render the string output based on the format."""
     if fmt == "tsv":
@@ -340,7 +355,14 @@ def render_output(
     elif fmt == "csv":
         return render_table(value_formats, details, ",", split=split, no_headers=no_headers)
     elif fmt == "html":
-        return render_html(prefixes, value_formats, predicate_ids, details, standalone=standalone, no_headers=no_headers)
+        return render_html(
+            prefixes,
+            value_formats,
+            predicate_ids,
+            details,
+            standalone=standalone,
+            no_headers=no_headers,
+        )
     else:
         raise Exception("Invalid format: " + fmt)
 
@@ -385,7 +407,14 @@ def render_table(value_formats, details, separator, split="|", no_headers=False)
 
 
 def export_terms(
-    database, terms, predicates, fmt, split="|", standalone=True, default_value_format="IRI", no_headers=False
+    database,
+    terms,
+    predicates,
+    fmt,
+    split="|",
+    standalone=True,
+    default_value_format="IRI",
+    no_headers=False,
 ):
     """Retrieve details for given terms and render in the given format."""
 
@@ -408,7 +437,13 @@ def export_terms(
         cur.execute("ATTACH DATABASE '' AS tmp")
         add_labels(cur)
 
-        term_ids = get_ids(cur, terms)
+        if terms:
+            term_ids = get_ids(cur, terms)
+        else:
+            term_ids = []
+            cur.execute("SELECT DISTINCT stanza FROM statements WHERE stanza NOT LIKE '_:%'")
+            for row in cur.fetchall():
+                term_ids.append(row["stanza"])
 
         if not predicates:
             # Get all predicates if not provided
@@ -446,7 +481,14 @@ def export_terms(
             details[term] = term_details
 
     return render_output(
-        prefixes, value_formats, predicate_ids, details, fmt, split=split, standalone=standalone, no_headers=no_headers
+        prefixes,
+        value_formats,
+        predicate_ids,
+        details,
+        fmt,
+        split=split,
+        standalone=standalone,
+        no_headers=no_headers,
     )
 
 


### PR DESCRIPTION
If a term or file containing terms is not currently provided, `gizmos.export` fails. I think that we should allow no term/terms, and return *all* terms in this case.

Note that this may end up including some unexpected terms, such as ontology annotation properties like `<http://protege.stanford.edu/plugins/owl/protege#defaultLanguage>`. Maybe we want to consider adding a selector like we have for ROBOT (e.g., classes, annotation properties...)

Alternatively, we could add a `--filter` option which accepts a fragment of a SQL query to limit the terms. For example, if you want all CL classes from the Cell Ontology:
```
python3 -m gizmos.export --filter "subject LIKE 'CL:%'" ... > out.tsv
```

The fragment would be everything after `WHERE` so that the user doesn't always have to include `SELECT stanza FROM statements WHERE ...` 

I like this filter idea because it gives a bit more fine-grained control. If I just return all classes from CL, I end up with PR and NCBITax classes, too, which I may not want in some cases.

## Update

I went ahead and added the `--filter` option. I think it's useful, but I can revert this change if you disagree. From the docs:

#### Terms

If you know the term or set of terms you wish to include in the export, you can use the `--term`/`--terms` options. The `term` (`-t` or `--term`) should be the CURIE or label of your desired term, and you can include more than one `-t` option. Mulitple terms can be specified with `-T <file>`/`--terms <file>` with each CURIE or label on one line.

If a term or terms are not included, *all* terms in the database will be returned. The set of all terms returned can be filtered using the `-F`/`--filter` option (note that this option will not do anything when you are using `--term` or `--terms`). The argument to filter should be a SQL-like statement to append after the `WHERE` clause, excluding the `WHERE`. For example:

```
python3 -m gizmos.export -d ont.db -F "subject LIKE 'EX:%'" > out.tsv
```

For information on the structure of the `statements` table, please see [RDFTab](https://github.com/ontodev/rdftab.rs).