### PR TITLE
Better handling of objects in logical axioms with export

### DIFF
--- a/gizmos/export.py
+++ b/gizmos/export.py
@@ -183,6 +183,7 @@ def get_logical_objects(cur, prefixes, term, predicate_ids):
     logical_objects = defaultdict(list)
 
     # TODO - support cardinality (if onClass, should have count)
+    # TODO - support queries on individuals, properties
     q = f"""SELECT DISTINCT s1.object AS pred, s2.object AS obj
         FROM statements s1 JOIN statements s2 ON s1.subject = s2.subject
         WHERE s1.stanza = "{term}"


### PR DESCRIPTION
While working with Cell Ontology, I wanted to export details about the plasma membrane parts. Currently, if you include "has plasma membrane part" as one of the predicates, it won't return any values, since this is a logical axiom on a class in the format
> 'has plasma membrane part' some foo

I think we should distinguish between object & annotation properties when retrieving values for `export` so that the object "foo" will be returned in the previous case. Right now, only object properties on classes are supported, and cardinality is not included. So if you had the axiom:
> 'has plasma membrane part' exactly 1 foo

.. it would just return "foo".

I'm leaving this as a draft PR because it may need some fleshing out, but it's a really convenient feature to have.

Note that there are some randoms diffs from running `black`, but these should go away once we merge in #63 