### PR TITLE
Fix "show all children" in tree

### DIFF
--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -1244,7 +1244,6 @@ def term2tree(data, treename, term_id, entity_type, href="?id={curie}", max_chil
             total = len(term_tree["children"])
             attrs = {"href": "javascript:show_children()"}
             children.append(["li", {"id": "more"}, ["a", attrs, f"Click to show all {total} ..."]])
-            break
     children = ["ul", {"id": "children"}] + children
     if len(children) == 0:
         children = ""


### PR DESCRIPTION
Resolves #66 

The `break` just meant that children stopped being appended to the list, so there were no children with the `display: none` attribute.