### PR TITLE
Add 'check' module

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This command will check that both the `prefix` and `statements` tables exist wit
 * missing index on `stanza` column
 * full IRIs that use a base defined in `prefix`
 
-All errors are logged, and if errors are found, the command will exit with status code `1`.
+All errors are logged, and if errors are found, the command will exit with status code `1`. Only the first 10 messages about specific rows in the `statements` table are logged to save time. If you wish to override this, use the `--limit <int>`/`-l <int>` option. To print all messages, include `--limit none`.
 
 ### `gizmos.export`
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ There are some dependencies that are test-only (e.g., will not be listed in the 
 
 Each `gizmos` module uses a SQL database version of an RDF or OWL ontology to create outputs. All SQL database inputs should be created from OWL using [rdftab](https://github.com/ontodev/rdftab.rs) to ensure they are in the right format. The database is specified by `-d`/`--database`.
 
+After loading the OWL into the database, we highly recommend creating an index on the `stanza` column to speed up operations. Other indexes are optional.
+```
+sqlite3 [path-to-database] "CREATE INDEX stanza_idx ON statements(stanza);"
+```
+
 ### `gizmos.check`
 
 The `check` module validates a SQLite database for use with other `gizmos` modules. We recommend running your database through `gizmos.check` before using the other commands.
@@ -26,6 +31,10 @@ This command will check that both the `prefix` and `statements` tables exist wit
 * all CURIEs use valid prefixes
 * `stanza` is never a blank node
 * `stanza`, `subject`, and `predicate` are never `NULL`
+
+`check` will also warn on the following:
+* missing index on `stanza` column
+* full IRIs that use a base defined in `prefix`
 
 All errors are logged, and if errors are found, the command will exit with status code `1`.
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,21 @@ python3 setup.py pytest
 
 There are some dependencies that are test-only (e.g., will not be listed in the project requirements). If you try and run `pytest` alone, it may fail due to missing dependencies.
 
-## Modules
+### Databases
 
 Each `gizmos` module uses a SQL database version of an RDF or OWL ontology to create outputs. All SQL database inputs should be created from OWL using [rdftab](https://github.com/ontodev/rdftab.rs) to ensure they are in the right format. The database is specified by `-d`/`--database`.
+
+The following prefixes are required to be defined in the `prefix` table for the `gizmos` commands to work:
+* `owl`: `http://www.w3.org/2002/07/owl#`
+* `rdf`: `http://www.w3.org/1999/02/22-rdf-syntax-ns#`
+* `rdfs`: `http://www.w3.org/2000/01/rdf-schema#`
 
 After loading the OWL into the database, we highly recommend creating an index on the `stanza` column to speed up operations. Other indexes are optional.
 ```
 sqlite3 [path-to-database] "CREATE INDEX stanza_idx ON statements(stanza);"
 ```
+
+## Modules
 
 ### `gizmos.check`
 
@@ -27,7 +34,8 @@ The `check` module validates a SQLite database for use with other `gizmos` modul
 python3 -m gizmos.check [path-to-database]
 ```
 
-This command will check that both the `prefix` and `statements` tables exist with valid columns as defined by [rdftab](https://github.com/ontodev/rdftab.rs). If those tables are valid, it checks the contents of `statements` to make sure that:
+This command will check that both the `prefix` and `statements` tables exist with valid columns as defined by [rdftab](https://github.com/ontodev/rdftab.rs). If those tables are valid, it checks the contents of `prefix` and `statements` to make sure that:
+* required prefixes are defined (see [Databases](#databases))
 * all CURIEs use valid prefixes
 * `stanza` is never a blank node
 * `stanza`, `subject`, and `predicate` are never `NULL`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ There are some dependencies that are test-only (e.g., will not be listed in the 
 
 Each `gizmos` module uses a SQL database version of an RDF or OWL ontology to create outputs. All SQL database inputs should be created from OWL using [rdftab](https://github.com/ontodev/rdftab.rs) to ensure they are in the right format. The database is specified by `-d`/`--database`.
 
+### `gizmos.check`
+
+The `check` module validates a SQLite database for use with other `gizmos` modules. We recommend running your database through `gizmos.check` before using the other commands.
+```
+python3 -m gizmos.check [path-to-database]
+```
+
+This command will check that both the `prefix` and `statements` tables exist with valid columns as defined by [rdftab](https://github.com/ontodev/rdftab.rs). If those tables are valid, it checks the contents of `statements` to make sure that:
+* all CURIEs use valid prefixes
+* `stanza` is never a blank node
+* `stanza`, `subject`, and `predicate` are never `NULL`
+
+All errors are logged, and if errors are found, the command will exit with status code `1`.
+
 ### `gizmos.export`
 
 The `export` module creates a table (default TSV) output containing the terms and their predicates written to stdout.

--- a/gizmos/check.py
+++ b/gizmos/check.py
@@ -1,0 +1,142 @@
+import logging
+import sqlite3
+import sys
+
+from argparse import ArgumentParser
+
+
+def check_prefix(cur):
+    """Check the structure of the prefix table. It must have the columns 'prefix' and 'base'."""
+    logger = logging.getLogger()
+
+    cur.execute("PRAGMA table_info(prefix)")
+    columns = {x[1]: x[2] for x in cur.fetchall()}
+    missing = []
+    bad_type = []
+    for col in ["prefix", "base"]:
+        coltype = columns.get(col)
+        if not coltype:
+            missing.append(col)
+        elif coltype != "TEXT":
+            bad_type.append(col)
+    if missing:
+        logger.error("'prefix' is missing column(s): " + ", ".join(missing))
+        return False
+    if bad_type:
+        logger.error("'prefix' column(s) do not have type 'TEXT': " + ", ".join(bad_type))
+        return False
+    return True
+
+
+def check_statements(cur):
+    """Check the structure of the statements table then check the values of the columns."""
+    logger = logging.getLogger()
+    statements_ok = True
+
+    # First check the structure
+    cur.execute("PRAGMA table_info(statements)")
+    columns = {x[1]: x[2] for x in cur.fetchall()}
+    missing = []
+    bad_type = []
+    for col in [
+        "stanza",
+        "subject",
+        "predicate",
+        "object",
+        "value",
+        "datatype",
+        "language",
+    ]:
+        coltype = columns.get(col)
+        if not coltype:
+            missing.append(col)
+        elif coltype != "TEXT":
+            bad_type.append(col)
+    if missing:
+        logger.error("'statements' is missing column(s): " + ", ".join(missing))
+        return False
+    if bad_type:
+        logger.error(
+            "'statements' column(s) do not have type 'TEXT': " + ", ".join(bad_type)
+        )
+        return False
+
+    # Get prefixes to check against
+    cur.execute("SELECT prefix, base FROM prefix")
+    prefixes = {x[0]: x[1] for x in cur.fetchall()}
+
+    # Check subjects, stanzas, predicates, and objects
+    for col in ["stanza", "subject", "predicate", "object"]:
+        cur.execute(f"SELECT {col} FROM statements")
+        for row in cur.fetchall():
+            value = row[0]
+            if value is None:
+                if col != "object":
+                    # Object can be null when there is a value
+                    logger.error(f"{col} cannot be NULL")
+                continue
+            if value.startswith("<") and value.endswith(">"):
+                iri = value.lstrip("<").rstrip(">")
+                for prefix, base in prefixes.items():
+                    if iri.startswith(base):
+                        logger.warning(f"{col} '{value}' can use prefix '{prefix}'")
+                continue
+            if ":" not in value:
+                logger.error(f"{col} '{value}' is not a valid CURIE")
+                statements_ok = False
+                continue
+            if value.startswith("_:"):
+                if col == "stanza":
+                    # Stanza should never be blank node, everything else is OK
+                    # TODO: should we warn on blank predicate?
+                    logger.error(
+                        f"{col} '{value}' should be a named entity"
+                    )
+                    statements_ok = False
+                continue
+            prefix = value.split(":")[0]
+            if prefix not in prefixes:
+                logger.error(
+                    f"{col} '{value}' does not have a valid prefix"
+                )
+                statements_ok = False
+    return statements_ok
+
+
+def main():
+    p = ArgumentParser()
+    p.add_argument("db", help="Path to SQLite database to check")
+    args = p.parse_args()
+
+    # Set up logger
+    logger = logging.getLogger()
+    ch = logging.StreamHandler()
+    formatter = logging.Formatter("%(levelname)s: %(message)s")
+    ch.setFormatter(formatter)
+    logger.setLevel(logging.WARNING)
+    ch.setLevel(logging.WARNING)
+    logger.addHandler(ch)
+
+    with sqlite3.connect(args.db) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT name FROM sqlite_master WHERE type='table';")
+        tables = [x[0] for x in cur.fetchall()]
+
+        if "prefix" not in tables:
+            logger.error("missing 'prefix' table")
+            prefix_ok = False
+        else:
+            prefix_ok = check_prefix(cur)
+
+        if "statements" not in tables:
+            logger.error("missing 'statements' table")
+            statements_ok = False
+        elif prefix_ok:
+            statements_ok = check_statements(cur)
+
+    if not statements_ok or not prefix_ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/gizmos/check.py
+++ b/gizmos/check.py
@@ -9,6 +9,7 @@ def check_prefix(cur):
     """Check the structure of the prefix table. It must have the columns 'prefix' and 'base'."""
     logger = logging.getLogger()
 
+    # Check for required columns
     cur.execute("PRAGMA table_info(prefix)")
     columns = {x[1]: x[2] for x in cur.fetchall()}
     missing = []
@@ -25,6 +26,17 @@ def check_prefix(cur):
     if bad_type:
         logger.error("'prefix' column(s) do not have type 'TEXT': " + ", ".join(bad_type))
         return False
+
+    # Check for required prefixes
+    missing_prefixes = []
+    for prefix in ["owl", "rdf", "rdfs"]:
+        cur.execute("SELECT * FROM prefix WHERE prefix = ?", (prefix,))
+        res = cur.fetchone()
+        if not res:
+            missing_prefixes.append(prefix)
+    if missing_prefixes:
+        logger.error("'prefix' is missing required prefixes: " + ", ".join(missing_prefixes))
+
     return True
 
 


### PR DESCRIPTION
Resolves #70 

### `gizmos.check`

The `check` module validates a SQLite database for use with other `gizmos` modules. We recommend running your database through `gizmos.check` before using the other commands.
```
python3 -m gizmos.check [path-to-database]
```

This command will check that both the `prefix` and `statements` tables exist with valid columns as defined by [rdftab](https://github.com/ontodev/rdftab.rs). If those tables are valid, it checks the contents of `statements` to make sure that:
* all CURIEs use valid prefixes
* `stanza` is never a blank node
* `stanza`, `subject`, and `predicate` are never `NULL`

`check` will also warn on the following:
* missing index on `stanza` column
* full IRIs that use a base defined in `prefix`

All errors are logged, and if errors are found, the command will exit with status code `1`.