### PR TITLE
Update search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ python3 -m gizmos.search [path-to-database] [search-text] > [output-json]
 ```
 
 Usage in Python (with defaults for optional parameters):
-```
+```python
 json = gizmos.search(    # returns: JSON string
     database,            # string: path to database
     search_text,         # string: text to search
@@ -126,15 +126,15 @@ python3 -m gizmos.tree [path-to-database] [term] > [output-html]
 ```
 
 Usage in Python (with defaults for optional parameters):
-```
-html = gizmos.tree(       # returns: HTML string
-    database,             # string: path to database
-    term_id,              # string: term ID to show or None
-    href="?id={curie}",   # string: format for hrefs
-    title=None,           # string: title to display
-    predicate_ids=None,   # list: IDs of predicates to include
-    include_search=False, # boolean: if True, include search bar
-    standalone=True       # boolean: if False, do not include HTML headers
+```python
+html = gizmos.tree(        # returns: HTML string
+    database,              # string: path to database
+    term_id,               # string: term ID to show or None
+    href="?id={curie}",    # string: format for hrefs
+    title=None,            # string: title to display
+    predicate_ids=None,    # list: IDs of predicates to include
+    include_search=False,  # boolean: if True, include search bar
+    standalone=True        # boolean: if False, do not include HTML headers
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ python3 -m gizmos.search [path-to-database] [search-text] > [output-json]
 
 Usage in Python (with defaults for optional parameters):
 ```
-json = gizmos.search(
+json = gizmos.search(    # returns: JSON string
     database,            # string: path to database
     search_text,         # string: text to search
     label="rdfs:label",  # string: term ID for label
@@ -127,7 +127,7 @@ python3 -m gizmos.tree [path-to-database] [term] > [output-html]
 
 Usage in Python (with defaults for optional parameters):
 ```
-gizmos.tree(
+html = gizmos.tree(       # returns: HTML string
     database,             # string: path to database
     term_id,              # string: term ID to show or None
     href="?id={curie}",   # string: format for hrefs

--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ Each returned object has the following attributes:
 
 By default, the label will use the `rdfs:label` property. You can override this with `--label <term>`/`-L <term>`.
 
-A short label is only included if you include a property with `--short-label <term>`/`-S <term>`. The same goes for synonyms, which are only included if `--synonym`/`-s <term>` is specified. You may include more than one synonym property with multiple `-s` options. Synonyms are only shown in the search result if they match the search text, whereas a short label is always shown (if the term has one).
+A short label is only included if you include a property with `--short-label <term>`/`-S <term>`. To set the short label to the term's ID, use `--short-label ID`. The same goes for synonyms, which are only included if `--synonym`/`-s <term>` is specified. You may include more than one synonym property with multiple `-s` options. Synonyms are only shown in the search result if they match the search text, whereas a short label is always shown (if the term has one).
 
 When both short label and synonym(s) are provided and the matching term has both properties, the search result is shown as:
 
-> label - short label - synonym
+> short label - label - synonym
 
 Search is run over all three properties, so even if a term's label does not match the text, it may still be returned if the synonym matches.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,47 @@ The output contains the specified term and all its ancestors up to `owl:Thing`. 
 
 You may also specify which predicates you would like to include with `-p <term>`/`--predicate <term>` or `-P <file>`/`--predicates <file>`, where the file contains a list of predicate CURIEs or labels. Otherwise, the output includes all predicates. Since this extracts a hierarchy, unless you include the `-n` flag, `rdfs:subClassOf` will always be included.
 
+### `gizmos.search`
+
+The `search` module returns a list of JSON objects for use with the tree browser search bar.
+
+Usage in the command line:
+```
+python3 -m gizmos.search [path-to-database] [search-text] > [output-json]
+```
+
+Usage in Python (with defaults for optional parameters):
+```
+json = gizmos.search(
+    database,            # string: path to database
+    search_text,         # string: text to search
+    label="rdfs:label",  # string: term ID for label
+    short_label=None,    # string: term ID for short label
+    synonyms=None,       # list: term IDs for synonyms
+    limit=30             # int: max results to return
+)
+```
+
+Each returned object has the following attributes:
+* `id`: The term ID
+* `label`: The term `rdfs:label` (or other property if specified)
+* `short_label`: The term's short label property value, if provided
+* `synonym`: The term's synonym property value, if provided
+* `property`: The term ID of the matched property (e.g., `rdfs:label`)
+* `order`: The order in which the term will appear in the search results, from shortest to longest match
+
+By default, the label will use the `rdfs:label` property. You can override this with `--label <term>`/`-L <term>`.
+
+A short label is only included if you include a property with `--short-label <term>`/`-S <term>`. The same goes for synonyms, which are only included if `--synonym`/`-s <term>` is specified. You may include more than one synonym property with multiple `-s` options. Synonyms are only shown in the search result if they match the search text, whereas a short label is always shown (if the term has one).
+
+When both short label and synonym(s) are provided and the matching term has both properties, the search result is shown as:
+
+> label - short label - synonym
+
+Search is run over all three properties, so even if a term's label does not match the text, it may still be returned if the synonym matches.
+
+Finally, the search only returns the first 30 results by default. If you wish to return less or more, you can specify this with `--limit <int>`/`-l <int>`.
+
 ### `gizmos.tree`
 
 The `tree` module produces a CGI tree browser for a given term contained in a SQL database.
@@ -84,11 +125,24 @@ Usage in the command line:
 python3 -m gizmos.tree [path-to-database] [term] > [output-html]
 ```
 
+Usage in Python (with defaults for optional parameters):
+```
+gizmos.tree(
+    database,             # string: path to database
+    term_id,              # string: term ID to show or None
+    href="?id={curie}",   # string: format for hrefs
+    title=None,           # string: title to display
+    predicate_ids=None,   # list: IDs of predicates to include
+    include_search=False, # boolean: if True, include search bar
+    standalone=True       # boolean: if False, do not include HTML headers
+)
+```
+
 The `term` should be a CURIE with a prefix already defined in the `prefix` table of the database. If the `term` is not included, the output will show a tree starting at `owl:Thing`.
 
 This can be useful when writing scripts that return trees from different databases.
 
-If you provide the `-s`/`--include-search` flag, a search bar will be included in the page. This search bar uses [typeahead.js](https://twitter.github.io/typeahead.js/) and expects the output of `gizmos.search`. The URL for the fetching the data for [Bloodhound](https://github.com/twitter/typeahead.js/blob/master/doc/bloodhound.md) is `?text=[search-text]&format=json`, or `?db=[db]&text=[search-text]&format=json` if the `-d` flag is also provided. The `format=json` is provided as a flag for use in scripts. See the CGI Example below for details on implementation.
+If you provide the `-s`/`--include-search` flag, a search bar will be included in the page. This search bar uses [typeahead.js](https://twitter.github.io/typeahead.js/) and expects the output of [`gizmos.search`](#gizmos.search). The URL for the fetching the data for [Bloodhound](https://github.com/twitter/typeahead.js/blob/master/doc/bloodhound.md) is `?text=[search-text]&format=json`, or `?db=[db]&text=[search-text]&format=json` if the `-d` flag is also provided. The `format=json` is provided as a flag for use in scripts. See the CGI Example below for details on implementation.
 
 The title displayed in the HTML output is the database file name. If you'd like to override this, you can use the `-t <title>`/`--title <title>` option. This is full HTML page. If you just want the content without `<html>` and `<body>` tags, include `-c`/`--content-only`.
 

--- a/gizmos/search.py
+++ b/gizmos/search.py
@@ -3,6 +3,7 @@ import sqlite3
 import sys
 
 from argparse import ArgumentParser
+from collections import defaultdict
 from .helpers import dict_factory
 
 
@@ -10,43 +11,162 @@ def main():
     p = ArgumentParser()
     p.add_argument("db", help="SQLite database to search for labels")
     p.add_argument("text", nargs="?", help="Text to search")
+    p.add_argument(
+        "-L", "--label", help="Property for labels, default rdfs:label", default="rdfs:label"
+    )
+    p.add_argument("-S", "--short-label", help="Property for short labels, default is excluded")
+    p.add_argument(
+        "-s",
+        "--synonyms",
+        help="A property to include as synonym, default is excluded",
+        action="append",
+    )
     p.add_argument("-l", "--limit", help="Limit for number of results", type=int, default=30)
     args = p.parse_args()
-    sys.stdout.write(search(args.db, args.text, args.limit))
+    sys.stdout.write(
+        search(
+            args.db,
+            args.text,
+            label=args.label,
+            short_label=args.short_label,
+            synonyms=args.synonyms,
+            limit=args.limit,
+        )
+    )
 
 
-def search(db, text, limit=30):
-    names = get_names(db, text, limit)
+def search(db, text, label="rdfs:label", short_label=None, synonyms=None, limit=30):
+    names = get_names(db, text, limit, label=label, short_label=short_label, synonyms=synonyms)
     return json.dumps(names, indent=4)
 
 
-def get_names(db_path, text, limit):
+def get_names(db_path, text, limit, label="rdfs:label", short_label=None, synonyms=None):
     """Return a list of name details.
     Each item in the list is a dict containing 'display_name' (label) and 'value' (CURIE)."""
-    names = []
+    names = defaultdict(dict)
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = dict_factory
         cur = conn.cursor()
         if text:
+            # Get labels
             cur.execute(
                 f"""SELECT DISTINCT subject, value
-                            FROM statements
-                            WHERE predicate = "rdfs:label"
-                            AND value LIKE "%{text}%"
-                            ORDER BY length(value)
-                            LIMIT {limit}"""
+                    FROM statements
+                    WHERE predicate = "{label}"
+                    AND value LIKE "%{text}%";"""
             )
+            for res in cur.fetchall():
+                term_id = res["subject"]
+                if term_id not in names:
+                    names[term_id] = dict()
+                names[term_id]["label"] = res["value"]
+
+            # Get short labels
+            if short_label:
+                cur.execute(
+                    f"""SELECT DISTINCT subject, value
+                        FROM statements
+                        WHERE predicate = "{short_label}"
+                        AND value LIKE "%{text}%";"""
+                )
+                for res in cur.fetchall():
+                    term_id = res["subject"]
+                    if term_id not in names:
+                        names[term_id] = dict()
+                    names[term_id]["short_label"] = res["value"]
+
+            # Get synonyms
+            if synonyms:
+                for syn in synonyms:
+                    cur.execute(
+                        f"""SELECT DISTINCT subject, value
+                            FROM statements
+                            WHERE predicate = "{syn}"
+                            AND value LIKE "%{text}%";"""
+                    )
+                    for res in cur.fetchall():
+                        term_id = res["subject"]
+                        value = res["value"]
+                        if term_id not in names:
+                            names[term_id] = dict()
+                            ts = dict()
+                        else:
+                            ts = names[term_id].get("synonyms", dict())
+                        ts[value] = syn
+                        names[term_id]["synonyms"] = ts
+
         else:
+            # No text, no results
+            return []
+
+    search_res = {}
+    term_to_match = {}
+    for term_id, details in names.items():
+        term_label = details.get("label")
+        term_short_label = details.get("short_label")
+        term_synonyms = details.get("synonyms", {})
+
+        # Determine which property was the text that matched
+        matched_property = None
+        term_synonym = None
+        matched_value = None
+        if term_label:
+            matched_property = label
+            matched_value = term_label
+        elif term_short_label:
+            matched_property = short_label
+            matched_value = term_short_label
+        elif term_synonyms:
+            # May be more than one, but we will just grab the first and go
+            matched_property = list(term_synonyms.values())[0]
+            term_synonym = list(term_synonyms.keys())[0]
+            matched_value = term_synonym
+
+        if not matched_property:
+            # We shouldn't get here, but this means that nothing actually matched
+            continue
+
+        # Add the other, missing property values
+        if not term_label:
+            # Label did not match text, retrieve it to display
             cur.execute(
-                f"""SELECT DISTINCT subject, value
-                            FROM statements
-                            WHERE predicate = "rdfs:label"
-                            ORDER BY length(value)
-                            LIMIT {limit}"""
+                "SELECT DISTINCT value FROM statements WHERE predicate = ? AND stanza = ?",
+                (label, term_id),
             )
-        for res in cur.fetchall():
-            names.append({"display_name": res["value"], "value": res["subject"]})
-    return names
+            res = cur.fetchone()
+            if res:
+                term_label = res["value"]
+
+        if not term_short_label:
+            # Short label did not match text, retrieve it to display
+            cur.execute(
+                "SELECT DISTINCT value FROM statements WHERE predicate = ? AND stanza = ?",
+                (short_label, term_id),
+            )
+            res = cur.fetchone()
+            if res:
+                term_short_label = res["value"]
+
+        term_to_match[term_id] = matched_value
+        # Add results to JSON output
+        search_res[term_id] = {
+            "id": term_id,
+            "label": term_label,
+            "short_label": term_short_label,
+            "synonym": term_synonym,
+            "property": matched_property,
+        }
+
+    # Order the matched values by length, shortest first, regardless of matched property
+    term_to_match = sorted(term_to_match, key=lambda key: len(term_to_match[key]))[:limit]
+    res = []
+    i = 1
+    for term in term_to_match:
+        details = search_res[term]
+        details["order"] = i
+        res.append(details)
+        i += 1
+    return res
 
 
 if __name__ == "__main__":

--- a/gizmos/search.py
+++ b/gizmos/search.py
@@ -151,7 +151,7 @@ def get_names(db_path, text, limit, label="rdfs:label", short_label=None, synony
 
         if not term_short_label:
             # Short label did not match text, retrieve it to display
-            if short_label.lower() == "id":
+            if short_label and short_label.lower() == "id":
                 if term_id.startswith("<") and term_id.endswith(">"):
                     term_short_label = term_id[1:-1]
                 else:

--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -473,7 +473,7 @@ function configure_typeahead(node) {
   }
   table = node.id.replace("-typeahead", "");
   var bloodhound = new Bloodhound({
-    datumTokenizer: Bloodhound.tokenizers.obj.nonword('label', 'short_label', 'synonym'),
+    datumTokenizer: Bloodhound.tokenizers.obj.nonword('short_label', 'label', 'synonym'),
     queryTokenizer: Bloodhound.tokenizers.nonword,
     sorter: function(a, b) {
       return a.order - b.order;
@@ -497,13 +497,15 @@ function configure_typeahead(node) {
     source: bloodhound,
     display: function(item) {
       if (item.label && item.short_label && item.synonym) {
-        return item.label + ' - ' + item.short_label + ' - ' + item.synonym;
+        return item.short_label + ' - ' + item.label + ' - ' + item.synonym;
       } else if (item.label && item.short_label) {
-        return item.label + ' - ' + item.short_label;
+        return item.short_label + ' - ' + item.label;
       } else if (item.label && item.synonym) {
         return item.label + ' - ' + item.synonym;
       } else if (item.short_label && item.synonym) {
         return item.short_label + ' - ' + item.synonym;
+      } else if (item.short_label && !item.label) {
+        return item.short_label;
       } else {
         return item.label;
       }

--- a/gizmos/tree.py
+++ b/gizmos/tree.py
@@ -451,90 +451,95 @@ def build_tree(
             # Add tree name to query params
             remote = f"'?db={treename}&text=%QUERY&format=json'"
         js += (
-            """$('#search-form').submit(function () {
-        $(this)
-            .find('input[name]')
-            .filter(function () {
-                return !this.value;
-            })
-            .prop('name', '');
-    });
-    function jump(currentPage) {
-      newPage = prompt("Jump to page", currentPage);
-      if (newPage) {
-        href = window.location.href.replace("page="+currentPage, "page="+newPage);
-        window.location.href = href
-      }
-    };
-    function configure_typeahead(node) {
-      if (!node.id || !node.id.endsWith("-typeahead")) {
-        return;
-      }
-      table = node.id.replace("-typeahead", "")
-      var bloodhound = new Bloodhound({
-        datumTokenizer: Bloodhound.tokenizers.obj.nonword('display_name'),
-        queryTokenizer: Bloodhound.tokenizers.nonword,
-        sorter: function(a, b) {
-          A = a['display_name'].length;
-          B = b['display_name'].length;
-          if (A < B) {
-             return -1;
-          }
-          else if (A > B) {
-             return 1;
-          }
-          else return 0;
-        },
-        remote: {
-          url: """
+            """
+$('#search-form').submit(function () {
+    $(this)
+        .find('input[name]')
+        .filter(function () {
+            return !this.value;
+        })
+        .prop('name', '');
+});
+function jump(currentPage) {
+  newPage = prompt("Jump to page", currentPage);
+  if (newPage) {
+    href = window.location.href.replace("page="+currentPage, "page="+newPage);
+    window.location.href = href;
+  }
+}
+function configure_typeahead(node) {
+  if (!node.id || !node.id.endsWith("-typeahead")) {
+    return;
+  }
+  table = node.id.replace("-typeahead", "");
+  var bloodhound = new Bloodhound({
+    datumTokenizer: Bloodhound.tokenizers.obj.nonword('label', 'short_label', 'synonym'),
+    queryTokenizer: Bloodhound.tokenizers.nonword,
+    sorter: function(a, b) {
+      return a.order - b.order;
+    },
+    remote: {
+      url: """
             + remote
             + """,
-          wildcard: '%QUERY',
-          transform : function(response) {
-              return bloodhound.sorter(response)
-          }
-        }
-      });
-      $(node).typeahead({
-        minLength: 0,
-        hint: false,
-        highlight: true
-      }, {
-        name: table,
-        source: bloodhound,
-        display: 'display_name',
-        limit: 40
-      });
-      $(node).bind('click', function(e) {
-        $(node).select();
-      });
-      $(node).bind('typeahead:select', function(ev, suggestion) {
-        $(node).prev().val(suggestion['value']);
-        go(table, suggestion['value'])
-      });
-      $(node).bind('keypress',function(e) {
-        if(e.which == 13) {
-          go(table, $('#' + table + '-hidden').val());
-        }
-      });
-    };
-    $('.typeahead').each(function() { configure_typeahead(this); });
-    function go(table, value) {
-      q = {}
-      table = table.replace('_all', '');
-      q[table] = value
-      window.location = query(q);
-    };
-    function query(obj) {
-      var str = [];
-      for (var p in obj)
-        if (obj.hasOwnProperty(p)) {
-          """
+      wildcard: '%QUERY',
+      transform : function(response) {
+          return bloodhound.sorter(response);
+      }
+    }
+  });
+  $(node).typeahead({
+    minLength: 0,
+    hint: false,
+    highlight: true
+  }, {
+    name: table,
+    source: bloodhound,
+    display: function(item) {
+      if (item.label && item.short_label && item.synonym) {
+        return item.label + ' - ' + item.short_label + ' - ' + item.synonym;
+      } else if (item.label && item.short_label) {
+        return item.label + ' - ' + item.short_label;
+      } else if (item.label && item.synonym) {
+        return item.label + ' - ' + item.synonym;
+      } else if (item.short_label && item.synonym) {
+        return item.short_label + ' - ' + item.synonym;
+      } else {
+        return item.label;
+      }
+    },
+    limit: 40
+  });
+  $(node).bind('click', function(e) {
+    $(node).select();
+  });
+  $(node).bind('typeahead:select', function(ev, suggestion) {
+    $(node).prev().val(suggestion.id);
+    go(table, suggestion.id);
+  });
+  $(node).bind('keypress',function(e) {
+    if(e.which == 13) {
+      go(table, $('#' + table + '-hidden').val());
+    }
+  });
+}
+$('.typeahead').each(function() { configure_typeahead(this); });
+function go(table, value) {
+  q = {}
+  table = table.replace('_all', '');
+  q[table] = value
+  window.location = query(q);
+}
+function query(obj) {
+  var str = [];
+  for (var p in obj)
+    if (obj.hasOwnProperty(p)) {
+      """
             + js_funct
             + """
-        }
-      return str.join("&");
-    }"""
+    }
+  return str.join("&");
+}"""
         )
 
     body.append(["script", {"type": "text/javascript"}, js])


### PR DESCRIPTION
Resolves #71 

### `gizmos.search`

The `search` module returns a list of JSON objects for use with the tree browser search bar.

Usage in the command line:
```
python3 -m gizmos.search [path-to-database] [search-text] > [output-json]
```

Usage in Python (with defaults for optional parameters):
```python
json = gizmos.search(    # returns: JSON string
    database,            # string: path to database
    search_text,         # string: text to search
    label="rdfs:label",  # string: term ID for label
    short_label=None,    # string: term ID for short label
    synonyms=None,       # list: term IDs for synonyms
    limit=30             # int: max results to return
)
```

Each returned object has the following attributes:
* `id`: The term ID
* `label`: The term `rdfs:label` (or other property if specified)
* `short_label`: The term's short label property value, if provided
* `synonym`: The term's synonym property value, if provided
* `property`: The term ID of the matched property (e.g., `rdfs:label`)
* `order`: The order in which the term will appear in the search results, from shortest to longest match

By default, the label will use the `rdfs:label` property. You can override this with `--label <term>`/`-L <term>`.

A short label is only included if you include a property with `--short-label <term>`/`-S <term>`. To set the short label to the term's ID, use `--short-label ID`. The same goes for synonyms, which are only included if `--synonym`/`-s <term>` is specified. You may include more than one synonym property with multiple `-s` options. Synonyms are only shown in the search result if they match the search text, whereas a short label is always shown (if the term has one).

When both short label and synonym(s) are provided and the matching term has both properties, the search result is shown as:

> short label - label - synonym

Search is run over all three properties, so even if a term's label does not match the text, it may still be returned if the synonym matches.

Finally, the search only returns the first 30 results by default. If you wish to return less or more, you can specify this with `--limit <int>`/`-l <int>`.