### PR TITLE
Add PostgreSQL support

### DIFF
--- a/.github/workflows/postgres-test.yml
+++ b/.github/workflows/postgres-test.yml
@@ -21,20 +21,17 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install .
-      - name: Test with pytest
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PW: postgres
-        run: |
-          pytest -k postgres
+      steps:
+        - uses: actions/checkout@v2
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v2
+          with:
+            python-version: ${{ matrix.python-version }}
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+            pip install .
+        - name: Test with pytest
+          run: |
+            pytest -k postgres

--- a/.github/workflows/postgres-test.yml
+++ b/.github/workflows/postgres-test.yml
@@ -21,17 +21,17 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-      steps:
-        - uses: actions/checkout@v2
-        - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v2
-          with:
-            python-version: ${{ matrix.python-version }}
-        - name: Install dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install -r requirements.txt
-            pip install .
-        - name: Test with pytest
-          run: |
-            pytest -k postgres
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install .
+      - name: Test with pytest
+        run: |
+          pytest -k postgres

--- a/.github/workflows/postgres-test.yml
+++ b/.github/workflows/postgres-test.yml
@@ -1,0 +1,40 @@
+name: PostgreSQL Test
+
+on: [push]
+
+jobs:
+  runner-job:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install .
+      - name: Test with pytest
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PW: postgres
+        run: |
+          pytest -k postgres

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -31,5 +31,9 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
+      env:
+        # Phony env variables for now; we are skipping PostgreSQL tests
+        POSTGRES_USER: foo
+        POSTGRES_PW: bar
       run: |
-        pytest
+        pytest -k sqlite

--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -31,8 +31,5 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
-      env:
-        POSTGRES_USER: postgres
-        POSTGRES_PW: postgres
       run: |
         pytest -k sqlite

--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python test
+name: SQLite Test
 
 on: [push]
 
@@ -32,8 +32,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       env:
-        # Phony env variables for now; we are skipping PostgreSQL tests
-        POSTGRES_USER: foo
-        POSTGRES_PW: bar
+        POSTGRES_USER: postgres
+        POSTGRES_PW: postgres
       run: |
         pytest -k sqlite

--- a/gizmos/search.py
+++ b/gizmos/search.py
@@ -1,51 +1,49 @@
 import json
-import sqlite3
 import sys
 
 from argparse import ArgumentParser
-from .helpers import dict_factory
+from .helpers import get_connection
 
 
 def main():
     p = ArgumentParser()
-    p.add_argument("db", help="SQLite database to search for labels")
+    p.add_argument("db", help="Database file (.db) or configuration (.ini)")
     p.add_argument("text", nargs="?", help="Text to search")
     p.add_argument("-l", "--limit", help="Limit for number of results", type=int, default=30)
     args = p.parse_args()
-    sys.stdout.write(search(args.db, args.text, args.limit))
+    conn = get_connection(args.db)
+    sys.stdout.write(search(conn, args.text, args.limit))
 
 
-def search(db, text, limit=30):
-    names = get_names(db, text, limit)
+def search(conn, text, limit=30):
+    names = get_names(conn, text, limit)
     return json.dumps(names, indent=4)
 
 
-def get_names(db_path, text, limit):
+def get_names(conn, text, limit):
     """Return a list of name details.
     Each item in the list is a dict containing 'display_name' (label) and 'value' (CURIE)."""
     names = []
-    with sqlite3.connect(db_path) as conn:
-        conn.row_factory = dict_factory
-        cur = conn.cursor()
-        if text:
-            cur.execute(
-                f"""SELECT DISTINCT subject, value
-                            FROM statements
-                            WHERE predicate = "rdfs:label"
-                            AND value LIKE "%{text}%"
-                            ORDER BY length(value)
-                            LIMIT {limit}"""
-            )
-        else:
-            cur.execute(
-                f"""SELECT DISTINCT subject, value
-                            FROM statements
-                            WHERE predicate = "rdfs:label"
-                            ORDER BY length(value)
-                            LIMIT {limit}"""
-            )
-        for res in cur.fetchall():
-            names.append({"display_name": res["value"], "value": res["subject"]})
+    cur = conn.cursor()
+    if text:
+        cur.execute(
+            f"""SELECT DISTINCT subject, value
+                        FROM statements
+                        WHERE predicate = "rdfs:label"
+                        AND value LIKE "%{text}%"
+                        ORDER BY length(value)
+                        LIMIT {limit}"""
+        )
+    else:
+        cur.execute(
+            f"""SELECT DISTINCT subject, value
+                        FROM statements
+                        WHERE predicate = "rdfs:label"
+                        ORDER BY length(value)
+                        LIMIT {limit}"""
+        )
+    for res in cur.fetchall():
+        names.append({"display_name": res[1], "value": res[0]})
     return names
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 black==19.10b0
 flake8==3.8.3
 html5lib==1.1
+psycopg2
 pyRdfa3==3.5.3
 pytest==6.0.2
 rdflib==5.0.0

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,5 +1,8 @@
+import psycopg2
+import sqlite3
+
 from gizmos.export import export_terms
-from util import test_db, create_db, compare_graphs
+from util import test_conn, test_db, create_postgresql_db, create_sqlite_db, compare_graphs
 
 
 def get_diff(actual_lines, expected_lines):
@@ -10,8 +13,8 @@ def get_diff(actual_lines, expected_lines):
     return removed + added
 
 
-def test_export(create_db):
-    tsv = export_terms(test_db, ["OBI:0100046"], ["CURIE", "label", "definition"], "tsv")
+def export(conn):
+    tsv = export_terms(conn, ["OBI:0100046"], ["CURIE", "label", "definition"], "tsv")
     actual_lines = tsv.split("\n")
 
     expected_lines = []
@@ -28,8 +31,8 @@ def test_export(create_db):
     assert not diff
 
 
-def test_export_no_predicates(create_db):
-    tsv = export_terms(test_db, ["OBI:0100046"], None, "tsv", default_value_format="CURIE")
+def export_no_predicates(conn):
+    tsv = export_terms(conn, ["OBI:0100046"], None, "tsv", default_value_format="CURIE")
     with open("test.tsv", "w") as f:
         f.write(tsv)
     actual_lines = tsv.split("\n")
@@ -47,3 +50,23 @@ def test_export_no_predicates(create_db):
         for line in diff:
             print(line)
     assert not diff
+
+
+def test_export_postgresql(create_postgresql_db):
+    with psycopg2.connect(test_conn) as conn:
+        export(conn)
+
+
+def test_export_no_predicates_postgresql(create_postgresql_db):
+    with psycopg2.connect(test_conn) as conn:
+        export(conn)
+
+
+def test_export_sqlite(create_sqlite_db):
+    with sqlite3.connect(test_db) as conn:
+        export(conn)
+
+
+def test_export_no_predicates_sqlite(create_sqlite_db):
+    with sqlite3.connect(test_db) as conn:
+        export(conn)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -53,12 +53,12 @@ def export_no_predicates(conn):
 
 
 def test_export_postgresql(create_postgresql_db):
-    with psycopg2.connect(test_conn) as conn:
+    with psycopg2.connect(**test_conn) as conn:
         export(conn)
 
 
 def test_export_no_predicates_postgresql(create_postgresql_db):
-    with psycopg2.connect(test_conn) as conn:
+    with psycopg2.connect(**test_conn) as conn:
         export(conn)
 
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,10 +1,13 @@
+import psycopg2
+import sqlite3
+
 from gizmos.extract import extract_terms
 from rdflib import Graph
-from util import test_db, create_db, compare_graphs
+from util import test_conn, test_db, create_postgresql_db, create_sqlite_db, compare_graphs
 
 
-def test_extract(create_db):
-    ttl = extract_terms(test_db, ["OBI:0100046"], ["rdfs:label", "IAO:0010000"])
+def extract(conn):
+    ttl = extract_terms(conn, ["OBI:0100046"], ["rdfs:label", "IAO:0010000"])
 
     actual = Graph()
     actual.parse(data=ttl, format="turtle")
@@ -13,3 +16,13 @@ def test_extract(create_db):
     expected.parse("tests/resources/obi-extract.ttl", format="turtle")
 
     compare_graphs(actual, expected)
+
+
+def test_extract_postgresql(create_postgresql_db):
+    with psycopg2.connect(test_conn) as conn:
+        extract(conn)
+
+
+def test_extract_sqlite(create_sqlite_db):
+    with sqlite3.connect(test_db) as conn:
+        extract(conn)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -19,7 +19,7 @@ def extract(conn):
 
 
 def test_extract_postgresql(create_postgresql_db):
-    with psycopg2.connect(test_conn) as conn:
+    with psycopg2.connect(**test_conn) as conn:
         extract(conn)
 
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,19 +1,18 @@
 import gizmos.tree
 import html5lib
+import psycopg2
 import sqlite3
 
 from pyRdfa.parse import parse_one_node
 from pyRdfa.state import ExecutionContext
 from pyRdfa.options import Options
 from rdflib import Graph
-from util import test_db, create_db, compare_graphs
+from util import test_conn, test_db, create_postgresql_db, create_sqlite_db, compare_graphs
 
 
-def check_term(term, predicates):
-    with sqlite3.connect(test_db) as conn:
-        conn.row_factory = gizmos.tree.dict_factory
-        cur = conn.cursor()
-        html = gizmos.tree.build_tree(cur, "obi", term, predicate_ids=predicates)
+def check_term(conn, term, predicates):
+    cur = conn.cursor()
+    html = gizmos.tree.build_tree(cur, "obi", term, predicate_ids=predicates)
 
     # Create the DOM document element
     parser = html5lib.HTMLParser(tree=html5lib.treebuilders.getTreeBuilder("dom"))
@@ -53,11 +52,22 @@ def check_term(term, predicates):
     compare_graphs(actual, expected)
 
 
-def test_tree(create_db):
-    check_term("OBI:0000666", [])
-    check_term("OBI:0000793", [])
+def tree(conn):
+    check_term(conn, "OBI:0000666", [])
+    check_term(conn, "OBI:0000793", [])
     check_term(
+        conn,
         "OBI:0000793",
         ["rdfs:label", "IAO:0000115", "rdfs:subClassOf", "owl:equivalentClass", "rdf:type"]
     )
-    check_term("OBI:0100046", [])
+    check_term(conn, "OBI:0100046", [])
+
+
+def test_tree_postgresql(create_postgresql_db):
+    with psycopg2.connect(test_conn) as conn:
+        tree(conn)
+
+
+def test_tree_sqlite(create_sqlite_db):
+    with sqlite3.connect(test_db) as conn:
+        tree(conn)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -64,7 +64,7 @@ def tree(conn):
 
 
 def test_tree_postgresql(create_postgresql_db):
-    with psycopg2.connect(test_conn) as conn:
+    with psycopg2.connect(**test_conn) as conn:
         tree(conn)
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,13 +4,22 @@ import os
 import psycopg2
 import pytest
 import sqlite3
+import sys
 
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from rdflib.compare import to_isomorphic, graph_diff
 
-
-test_conn = "dbname=gizmos_test user=postgres password=password"
 test_db = "build/obi.db"
+
+POSTGRES_USER = os.environ.get("POSTGRES_USER")
+POSTGRES_PW = os.environ.get("POSTGRES_PW")
+if not POSTGRES_USER:
+    logging.error("Missing POSTGRES_USER environment variable")
+    sys.exit(1)
+if not POSTGRES_PW:
+    logging.error("Missing POSTGRES_PW environment variable")
+    sys.exit(1)
+test_conn = f"dbname=gizmos_test user={POSTGRES_USER} password={POSTGRES_PW}"
 
 
 def dump_ttl_sorted(graph):
@@ -75,7 +84,7 @@ def create_db(conn):
 
 @pytest.fixture
 def create_postgresql_db():
-    with psycopg2.connect("user=postgres password=password") as conn:
+    with psycopg2.connect(f"user={POSTGRES_USER} password={POSTGRES_PW}") as conn:
         conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         cur = conn.cursor()
         cur.execute("SELECT datname FROM pg_database WHERE datname = 'gizmos_test';")

--- a/tests/util.py
+++ b/tests/util.py
@@ -11,15 +11,11 @@ from rdflib.compare import to_isomorphic, graph_diff
 
 test_db = "build/obi.db"
 
-POSTGRES_USER = os.environ.get("POSTGRES_USER")
-POSTGRES_PW = os.environ.get("POSTGRES_PW")
-if not POSTGRES_USER:
-    logging.error("Missing POSTGRES_USER environment variable")
-    sys.exit(1)
-if not POSTGRES_PW:
-    logging.error("Missing POSTGRES_PW environment variable")
-    sys.exit(1)
-test_conn = f"dbname=gizmos_test user={POSTGRES_USER} password={POSTGRES_PW}"
+POSTGRES_USER = os.environ.get("POSTGRES_USER", "postgres")
+POSTGRES_PW = os.environ.get("POSTGRES_PW", "postgres")
+POSTGRES_HOST = os.environ.get("POSTGRES_HOST", "localhost")
+POSTGRES_PORT = int(os.environ.get("POSTGRES_PORT", 5432))
+test_conn = {"host": POSTGRES_HOST, "database": "gizmos_test", "user": POSTGRES_USER, "password": POSTGRES_PW, "port": POSTGRES_PORT}
 
 
 def dump_ttl_sorted(graph):
@@ -84,14 +80,14 @@ def create_db(conn):
 
 @pytest.fixture
 def create_postgresql_db():
-    with psycopg2.connect(f"user={POSTGRES_USER} password={POSTGRES_PW}") as conn:
+    with psycopg2.connect(host=POSTGRES_HOST, user=POSTGRES_USER, password=POSTGRES_PW, port=POSTGRES_PORT) as conn:
         conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         cur = conn.cursor()
         cur.execute("SELECT datname FROM pg_database WHERE datname = 'gizmos_test';")
         res = cur.fetchone()
         if not res:
             cur.execute("CREATE DATABASE gizmos_test")
-    with psycopg2.connect(test_conn) as conn:
+    with psycopg2.connect(**test_conn) as conn:
         create_db(conn)
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,11 +1,15 @@
 import csv
+import logging
 import os
+import psycopg2
 import pytest
 import sqlite3
 
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from rdflib.compare import to_isomorphic, graph_diff
 
 
+test_conn = "dbname=gizmos_test user=postgres password=password"
 test_db = "build/obi.db"
 
 
@@ -30,41 +34,67 @@ def compare_graphs(actual, expected):
     assert actual_iso == expected_iso
 
 
+def create_db(conn):
+    cur = conn.cursor()
+
+    cur.execute("DROP TABLE IF EXISTS prefix")
+    cur.execute(
+        "CREATE TABLE prefix (" "  prefix TEXT PRIMARY KEY NOT NULL," "  base TEXT NOT NULL" ")"
+    )
+    with open("tests/resources/prefix.tsv") as f:
+        rows = list(csv.reader(f, delimiter="\t"))
+        for r in rows:
+            cur.execute(f"INSERT INTO prefix VALUES ('{r[0]}', '{r[1]}')")
+
+    cur.execute("DROP TABLE IF EXISTS statements")
+    cur.execute(
+        "CREATE TABLE statements ("
+        "  stanza TEXT,"
+        "  subject TEXT,"
+        "  predicate TEXT,"
+        "  object TEXT,"
+        "  value TEXT,"
+        "  datatype TEXT,"
+        "  language TEXT"
+        ")"
+    )
+    with open("tests/resources/statements.tsv") as f:
+        rows = []
+        for row in csv.reader(f, delimiter="\t"):
+            rows.append([None if not x else x for x in row])
+        for r in rows:
+            query = []
+            for itm in r:
+                if not itm:
+                    query.append("NULL")
+                    continue
+                query.append("'" + itm.replace("'", "''") + "'")
+            query = ", ".join(query)
+            cur.execute(f"INSERT INTO statements VALUES ({query})")
+
+
 @pytest.fixture
-def create_db():
+def create_postgresql_db():
+    with psycopg2.connect("user=postgres password=password") as conn:
+        conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        cur = conn.cursor()
+        cur.execute("SELECT datname FROM pg_database WHERE datname = 'gizmos_test';")
+        res = cur.fetchone()
+        if not res:
+            cur.execute("CREATE DATABASE gizmos_test")
+    with psycopg2.connect(test_conn) as conn:
+        create_db(conn)
+
+
+@pytest.fixture
+def create_sqlite_db():
     build = os.path.dirname(test_db)
     if not os.path.isdir(build):
         os.mkdir(build)
 
     with sqlite3.connect(test_db) as conn:
-        cur = conn.cursor()
-
-        cur.execute("DROP TABLE IF EXISTS prefix")
-        cur.execute(
-            "CREATE TABLE prefix (" "  prefix TEXT PRIMARY KEY NOT NULL," "  base TEXT NOT NULL" ")"
-        )
-        with open("tests/resources/prefix.tsv") as f:
-            rows = list(csv.reader(f, delimiter="\t"))
-            cur.executemany("INSERT INTO prefix VALUES (?, ?)", rows[1:])
-
-        cur.execute("DROP TABLE IF EXISTS statements")
-        cur.execute(
-            "CREATE TABLE statements ("
-            "  stanza TEXT,"
-            "  subject TEXT,"
-            "  predicate TEXT,"
-            "  object TEXT,"
-            "  value TEXT,"
-            "  datatype TEXT,"
-            "  language TEXT"
-            ")"
-        )
-        with open("tests/resources/statements.tsv") as f:
-            rows = []
-            for row in csv.reader(f, delimiter="\t"):
-                rows.append([None if not x else x for x in row])
-            cur.executemany("INSERT INTO statements VALUES (?, ?, ?, ?, ?, ?, ?)", rows[1:])
+        create_db(conn)
 
 
 if __name__ == "__main__":
-    create_db()
+    create_sqlite_db()


### PR DESCRIPTION
Resolves #48

### Databases

Each `gizmos` module uses a SQL database version of an RDF or OWL ontology to create outputs. SQL database inputs should be created from OWL using [rdftab](https://github.com/ontodev/rdftab.rs) to ensure they are in the right format. RDFTab creates SQLite databases, but we also support PostgreSQL. The database is specified by `-d`/`--database`. 

When loading from a SQLite database, use the path to the database (`foo.db`). When loading a PostgreSQL database, use a path to a configuration file ending in `.ini` (e.g., `conf.ini`) with a `[postgresql]` section. We recommend that the configuration file contain at least `database`, `user`, and `password` fields. An example configuration file with all optional fields looks like:
```
[postgresql]
host = 127.0.0.1
database = my_ontology
user = postgres
password = secret_password
port = 5432
```

The following prefixes are required to be defined in the `prefix` table for the `gizmos` commands to work:
* `owl`: `http://www.w3.org/2002/07/owl#`
* `rdf`: `http://www.w3.org/1999/02/22-rdf-syntax-ns#`
* `rdfs`: `http://www.w3.org/2000/01/rdf-schema#`

After loading the OWL into the database, we highly recommend creating an index on the `stanza` column to speed up operations. Other indexes are optional.
```
sqlite3 [path-to-database] "CREATE INDEX stanza_idx ON statements(stanza);"
```

When using `gizmos` as a Python module, all operations accept a database connection object. For details on the Connection, see [Python Database API Connection Objects](https://www.python.org/dev/peps/pep-0249/#connection-objects). We support [sqlite3](https://docs.python.org/3/library/sqlite3.html) and [psycopg2](https://pypi.org/project/psycopg2/) (PostgreSQL). Using other connection objects may result in unanticipated errors due to slight variations in syntax.
