### PR TITLE
First pass at thick triples prototype

### DIFF
--- a/tests/prefix.tsv
+++ b/tests/prefix.tsv
@@ -1,0 +1,6 @@
+prefix	base
+rdf	http://www.w3.org/1999/02/22-rdf-syntax-ns#
+rdfs	http://www.w3.org/2000/01/rdf-schema#
+xsd	http://www.w3.org/2001/XMLSchema#
+owl	http://www.w3.org/2002/07/owl#
+ex	http://example.com/

--- a/tests/prototype.py
+++ b/tests/prototype.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+
+import csv
+import json
+import re
+
+from gizmos.hiccup import render
+
+
+prefixes = {}
+with open("tests/prefix.tsv") as fh:
+    rows = csv.DictReader(fh, delimiter="\t")
+    for row in rows:
+        if row.get("prefix"):
+            prefixes[row["prefix"]] = row["base"]
+
+with open("tests/thin.tsv") as fh:
+    thin = list(csv.DictReader(fh, delimiter="\t"))
+
+
+def renderSubjects(subjects):
+    """Print a nested subject dict as indented lines.
+    From
+        {"ex:s": {"ex:p": [{"object": "ex:o"}]}}
+    to
+        ex:s
+          ex:p
+            {"object": "ex:o"}
+    """
+    for subject_id in sorted(list(subjects.keys())):
+        print(subject_id)
+        for predicate in sorted(list(subjects[subject_id].keys())):
+            print(" ", predicate)
+            for obj in subjects[subject_id][predicate]:
+                print("   ", obj)
+
+
+def row2objectMap(row):
+    """Convert a row dict to an object map.
+    From
+        {"subject": "ex:s", "predicate": "ex:p", "object": "ex:o"}
+    to
+        {"object": "ex:o"}
+        {"value": "Foo"}
+        {"value": "Foo", "language": "en"}
+        {"value": "0.123", "datatype": "xsd:float"}
+    """
+    if row.get("object"):
+        return {"object": row["object"]}
+    elif row.get("value"):
+        if row.get("datatype"):
+            return {"value": row["value"], "datatype": row["datatype"]}
+        elif row.get("language"):
+            return {"value": row["value"], "language": row["language"]}
+        else:
+            return {"value": row["value"]}
+    else:
+        raise Exception("Invalid RDF row")
+
+
+def thin2subjects(thin):
+    """Convert a list of thin rows to a nested subjects map:
+    From
+        [{"subject": "ex:s", "predicate": "ex:p", "object": "ex:o"}]
+    to
+        {"ex:s": {"ex:p": [{"object": "ex:o"}]}}
+    """
+    dependencies = {}
+    subject_ids = set(x["subject"] for x in thin)
+    subjects = {}
+
+    # Convert rows to a subject dict.
+    for subject_id in subject_ids:
+        predicates = {}
+        for row in thin:
+            if row["subject"] != subject_id:
+                continue
+            predicate = row["predicate"]
+            if predicate not in predicates:
+                predicates[predicate] = []
+            objects = predicates[predicate]
+            objects.append(row2objectMap(row))
+            objects.sort(key=lambda k: str(k))
+            predicates[predicate] = objects
+            if row.get("object") and row["object"].startswith("_:"):
+                if not subject_id in dependencies:
+                    dependencies[subject_id] = set()
+                dependencies[subject_id].add(row["object"])
+        subjects[subject_id] = predicates
+        # print(subject_id, predicates)
+
+    # Work from leaves to root, nesting the blank structures.
+    while dependencies:
+        leaves = set(subjects.keys()) - set(dependencies.keys())
+        dependencies = {}
+        handled = set()
+        for subject_id, predicates in subjects.items():
+            for predicate in predicates.keys():
+                objects = []
+                for obj in predicates[predicate]:
+                    o = obj.get("object")
+                    if o and isinstance(o, str) and o.startswith("_:"):
+                        if o in leaves:
+                            obj = {"object": subjects[o]}
+                            handled.add(o)
+                        else:
+                            if not subject_id in dependencies:
+                                dependencies[subject_id] = set()
+                            dependencies[subject_id].add(o)
+                    objects.append(obj)
+                objects.sort(key=lambda k: str(k))
+                predicates[predicate] = objects
+        for subject_id in handled:
+            del subjects[subject_id]
+
+    # Handle OWL annotations and RDF reification.
+    # TODO!
+    for subject_id in subjects.keys():
+        if subjects[subject_id].get("owl:annotatedSubject"):
+            pass
+        if subjects[subject_id].get("owl:annotatedSubject"):
+            pass
+
+    return subjects
+
+
+def subjects2thick(subjects):
+    """Convert a nested subjects map to thick rows.
+    From
+        {"ex:s": {"ex:p": [{"object": {"ex:a": [{"value": "A"}]}}]}}
+    to
+        {"subject": "ex:s", "predicate": "ex:p", "object": "{\"ex:a\":[{\"value\": \"A\"}]}"}
+    """
+    rows = []
+    for subject_id in sorted(list(subjects.keys())):
+        for predicate in sorted(list(subjects[subject_id].keys())):
+            for obj in subjects[subject_id][predicate]:
+                result = {
+                    "subject": subject_id,
+                    "predicate": predicate,
+                    **obj
+                }
+                if result.get("object") and not isinstance(result["object"], str):
+                    result["object"] = json.dumps(result["object"])
+                rows.append(result)
+    return rows
+
+
+def thick2subjects(thick):
+    pass
+
+owlTypes = ["owl:Restriction"]
+
+def firstObject(predicates, predicate):
+    """Given a prediate map, return the first 'object'."""
+    if predicates.get(predicate):
+        for obj in predicates[predicate]:
+            if obj.get("object"):
+                return obj["object"]
+
+
+def rdf2list(predicates):
+    """Convert a nested RDF list to a simple list of objects.
+    From
+        {'rdf:type': [{'object': 'rdf:List'}],
+         'rdf:first': [{'value': 'A'}],
+         'rdf:rest': [{
+             'object': {
+                 'rdf:type': [{'object': 'rdf:List'}],
+                 'rdf:first': [{'value': 'B'}],
+                 'rdf:rest': [{'object': 'rdf:nil'}]}}]}}
+    to
+        [{"value": "A"}, {"value": "B"}]
+    """
+    result = []
+    if "rdf:first" in predicates:
+        result.append(predicates["rdf:first"][0])
+    if "rdf:rest" in predicates:
+        o = predicates["rdf:rest"][0]
+        if not o:
+            return result
+        if not o.get("object"):
+            return result
+        if o["object"] == "rdf:nil":
+            return result
+        return result + rdf2list(o["object"])
+    return result
+
+
+def rdf2ofs(predicates):
+    """Given a predicate map, try to return an OWL Functional S-Expression.
+    From
+        {'rdf:type': [{'object': 'owl:Restriction'}],
+         'owl:onProperty': [{'object': 'ex:part-of'}],
+         'owl:someValuesFrom': [{'object': 'ex:bar'}]}
+    to
+        ["ObjectSomeValuesFrom", "ex:part-of", "ex:bar"]
+    """
+    rdfType = firstObject(predicates, "rdf:type")
+    result = None
+    if rdfType == "owl:Restriction":
+        onProperty = firstObject(predicates, "owl:onProperty")
+        someValuesFrom = firstObject(predicates, "owl:someValuesFrom")
+        result = ["ObjectSomeValuesFrom", onProperty, someValuesFrom]
+    elif rdfType == "rdf:List":
+        result = ["RDFList"] + rdf2list(predicates)
+    # TODO: handle all the OFN types
+    else:
+        raise Exception(f"Unhandled type '{rdfType}' for: {predicates}")
+    return result
+
+
+def thick2reasoned(thick):
+    """Convert logical thick rows to reasoned rows.
+    From
+        [{"subject": "ex:a", "predicate": "owl:equivalentClass", "object": "ex:b"}]
+    to
+        [{"super": "ex:a", "sub": "ex:b"}
+         {"super": "ex:b", "sub": "ex:a"}]
+    """
+    reasoned = []
+    for row in thick:
+        owl = None
+        if row["predicate"] in ["rdfs:subClassOf", "owl:equivalentClass"]:
+            if row.get("object") and isinstance(row["object"], str):
+                if row["object"].startswith("{"):
+                    o = rdf2ofs(json.loads(row["object"]))
+                else:
+                    o = row["object"]
+            result = {
+                "super": o,
+                "sub": row["subject"],
+            }
+            reasoned.append(result)
+        if row["predicate"] in ["owl:equivalentClass"]:
+            result = {
+                "super": row["subject"],
+                "sub": o,
+            }
+            reasoned.append(result)
+    return reasoned
+
+
+def quote(label):
+    if re.search(r'\W', label):
+        return f"'{label}'"
+    return label
+
+
+def ofs2omn(labels, ofs):
+    first = ofs[0]
+    if first == "ObjectSomeValuesFrom":
+        onProperty = quote(labels.get(ofs[1], ofs[1]))
+        someValuesFrom = quote(labels.get(ofs[2], ofs[2]))
+        return f"{onProperty} some {someValuesFrom}"
+    # TODO: handle all the OFN types
+    else:
+        raise Exception(f"Unhandled expression type '{first}' for: {ofs}")
+
+
+def po2rdfa(labels, predicate, obj):
+    if isinstance(obj, str):
+        obj = {"object": obj}
+    if obj.get("object"):
+        o = obj["object"]
+        if isinstance(o, str):
+            if o.startswith("<"):
+                o = o[1:-1]
+            return [
+              "a",
+              {
+                "href": o,
+                "property": predicate,
+              },
+              labels.get(o, o),
+            ]
+        try:
+            return ofs2rdfa(labels, rdf2ofs(o))
+        except:
+            return ["span", str(o)]
+    elif obj.get("value"):
+        return [
+          "span",
+          {"property": predicate},
+          obj["value"],
+        ]
+    else:
+        raise Exception(f"Unhandled object: {obj}")
+
+
+def ofs2rdfa(labels, ofs):
+    """Convert an OFS list to an HTML vector."""
+    first = ofs[0]
+    if first == "ObjectSomeValuesFrom":
+        onProperty = po2rdfa(labels, "owl:onProperty", ofs[1])
+        someValuesFrom = po2rdfa(labels, "owl:someValuesFrom", ofs[2])
+        return ["span", onProperty, " some ", someValuesFrom]
+    elif first == "RDFList":
+        return ["span", "TODO " + str(ofs)]
+    # TODO: handle all the OFN types
+    else:
+        raise Exception(f"Unhandled expression type '{first}' for: {ofs}")
+
+
+def rows2labels(rows):
+    """Given a list of rows, return a map from subject to rdfs:label value."""
+    labels = {}
+    for row in rows:
+        if row["predicate"] == "rdfs:label":
+            labels[row["subject"]] = row["value"]
+    return labels
+
+
+def subject2rdfa(labels, subject_id, predicates):
+    """Convert a subject_id and predicate map to an HTML vector."""
+    html = ["ul"]
+    for predicate in sorted(list(predicates.keys())):
+        for obj in predicates[predicate]:
+            html.append(["li", po2rdfa(labels, predicate, obj)])
+    return ["li", subject_id, html]
+
+
+def subjects2rdfa(labels, subjects):
+    """Convert a subject_id and subjects map to an HTML vector."""
+    html = ["ul"]
+    for subject_id in sorted(list(subjects.keys())):
+        html.append(subject2rdfa(labels, subject_id, subjects[subject_id]))
+    return html
+
+
+if __name__ == "__main__":
+    rdfList = {'rdf:type': [{'object': 'rdf:List'}], 'rdf:first': [{'value': 'A'}], 'rdf:rest': [{'object': {'rdf:type': [{'object': 'rdf:List'}], 'rdf:first': [{'value': 'B'}], 'rdf:rest': [{'object': 'rdf:nil'}]}}]}
+    print("List", rdf2ofs(rdfList))
+
+    subjects = thin2subjects(thin)
+    #renderSubjects(subjects)
+    #for row in subjects2thick(subjects):
+    #    print(row)
+    thick = subjects2thick(subjects)
+    reasoned = thick2reasoned(thick)
+    ofs = reasoned[0]["super"]
+    labels = {
+        "ex:part-of": "part of",
+        "ex:bar": "Bar",
+    }
+    print("OFS", ofs)
+    print("OMN", ofs2omn(labels, ofs))
+    rdfa = ofs2rdfa(labels, ofs)
+    print("RDFa", rdfa)
+    print("HTML", render(prefixes, rdfa))
+    rdfa = subject2rdfa(labels, "ex:foo", subjects["ex:foo"])
+    #print("RDFa", rdfa)
+    print("HTML\n" + render(prefixes, rdfa))

--- a/tests/thick.tsv
+++ b/tests/thick.tsv
@@ -1,0 +1,8 @@
+subject	predicate	object	value	datatype	language	annotations	metadata
+ex:foo	rdfs:label		Foo				
+ex:foo	rdfs:label		Fou		fr		
+ex:foo	ex:size		123	xsd:int			
+ex:foo	ex:link	<https://example.com/foo>				"{""rdfs:comment"":[{""value"":""OWL axiom annotation"",""language"":""en""}]}"	"{""rdfs:comment"":[{""value"":""RDF metadata"",""language"":""en""}]}"
+ex:foo	rdf:type	owl:Class					
+ex:foo	rdfs:subClassOf	"{""rdf:type"":[{""object"":""owl:Restriction""}],""owl:onProperty"":[{""object"":""ex:part-of""}],""owl:someValuesFrom"":[{""object"":""ex:bar""}]}"					
+ex:foo	ex:items	"[{""value"":""A""},{""value"":""B""}]"					

--- a/tests/thin.tsv
+++ b/tests/thin.tsv
@@ -1,0 +1,27 @@
+stanza	subject	predicate	object	value	datatype	language
+ex:foo	ex:foo	rdfs:label		Foo		
+ex:foo	ex:foo	rdfs:label		Fou		fr
+ex:foo	ex:foo	ex:size		123	xsd:int	
+ex:foo	ex:foo	ex:link	<https://example.com/FOO>			
+ex:foo	ex:foo	rdf:type	owl:Class			
+ex:foo	ex:foo	rdfs:subClassOf	_:b1			
+ex:foo	_:b1	rdf:type	owl:Restriction			
+ex:foo	_:b1	owl:onProperty	ex:part-of			
+ex:foo	_:b1	owl:someValuesFrom	ex:bar			
+ex:foo	ex:foo	ex:items	_:b2			
+ex:foo	_:b2	rdf:type	rdf:List			
+ex:foo	_:b2	rdf:first		A		
+ex:foo	_:b2	rdf:rest	_:b3			
+ex:foo	_:b3	rdf:type	rdf:List			
+ex:foo	_:b3	rdf:first		B		
+ex:foo	_:b3	rdf:rest	rdf:nil			
+ex:foo	_:b4	rdf:type	owl:Axiom			
+ex:foo	_:b4	owl:annotatedSource	ex:foo			
+ex:foo	_:b4	owl:annotatedProperty	ex:link			
+ex:foo	_:b4	owl:annotatedTarget	<https://example.com/FOO>			
+ex:foo	_:b4	rdfs:comment		OWL axiom annotation		en
+ex:foo	_:b5	rdf:type	rdf:Statement			
+ex:foo	_:b5	rdf:subject	ex:foo			
+ex:foo	_:b5	rdf:predicate	ex:link			
+ex:foo	_:b5	rdf:object	<https://example.com/FOO>			
+ex:foo	_:b5	rdfs:comment		RDF metadata		en


### PR DESCRIPTION
Working from the [Thick Triples Examples](https://docs.google.com/spreadsheets/d/19zS8lHUM5cU_Nf9Rc7-TGL6wesOD8JLINJSan3DmPqE/edit#gid=1542421054) Google Sheet and the [Thick Triples Design](https://docs.google.com/document/d/1U3qghf7AaPIUty2MgwpciRRRW_3F9WSV5i-_mNwX9ek/edit#) Google Doc, this implements proofs of concept for:

- thin triples to subjects map
- render subjects map as indented lines
- subjects map to thick triples
- predicates map to OWL Functional S-Expression (OFS): `["ObjectSomeValuesFrom", "ex:part-of", "ex:bar"]`
- OFS to Manchester (OMN) with labels: `'part of' some Bar`
- OFS to HTML+RDFa, e.g. OMN with labels and links
- thick triples to HTML+RDFa

OWL axiom annotations and RDF reification aren't yet supported.