### PR TITLE
Fix export failing on missing predicate

### DIFF
--- a/gizmos/export.py
+++ b/gizmos/export.py
@@ -300,8 +300,8 @@ def render_html(prefixes, value_formats, predicate_ids, details, standalone=True
             else:
                 pred_label = h
 
-            predicate_id = predicate_labels[pred_label]
-            value_format = value_formats[h]
+            predicate_id = predicate_labels.get(pred_label)
+            value_format = value_formats.get(h)
             vo_list = detail.get(pred_label)
             if not vo_list:
                 tr.append(["td"])


### PR DESCRIPTION
If you pass a predicate that doesn't exist in the database to `export`, Gizmos will both warn you (e.g., `WARNING - 'obsolete' does not exist in database`) and fail (`KeyError: 'obsolete'`).

`export` should only warn and just return empty values for the missing predicate. We can always add a "strict" mode that fails on any terms missing from the database later.
