### PR TITLE
Fix bad rdfs:subClassOf axioms in extract

### DIFF
--- a/gizmos/extract.py
+++ b/gizmos/extract.py
@@ -341,8 +341,8 @@ def extract_terms(
         SELECT DISTINCT child, child, 'rdfs:subPropertyOf', parent
         FROM tmp_terms WHERE parent IS NOT NULL AND child IN
           (SELECT subject FROM statements WHERE predicate = 'rdf:type'
-           AND object IN ('owl:AnnotationProperty', 'owl:DataProperty', 'owl:ObjectProperty'))
-           AND subject NOT LIKE '_:%'"""
+           AND object IN ('owl:AnnotationProperty', 'owl:DataProperty', 'owl:ObjectProperty')
+           AND subject NOT LIKE '_:%')"""
     )
 
     # Insert subclass statements for any class types

--- a/gizmos/extract.py
+++ b/gizmos/extract.py
@@ -340,8 +340,9 @@ def extract_terms(
         """INSERT INTO tmp_extract (stanza, subject, predicate, object)
         SELECT DISTINCT child, child, 'rdfs:subPropertyOf', parent
         FROM tmp_terms WHERE parent IS NOT NULL AND child IN
-          (SELECT stanza FROM statements WHERE predicate = 'rdf:type'
-           AND object IN ('owl:AnnotationProperty', 'owl:DataProperty', 'owl:ObjectProperty'))"""
+          (SELECT subject FROM statements WHERE predicate = 'rdf:type'
+           AND object IN ('owl:AnnotationProperty', 'owl:DataProperty', 'owl:ObjectProperty'))
+           AND subject NOT LIKE '_:%'"""
     )
 
     # Insert subclass statements for any class types
@@ -349,7 +350,8 @@ def extract_terms(
         """INSERT INTO tmp_extract (stanza, subject, predicate, object)
         SELECT DISTINCT child, child, 'rdfs:subClassOf', parent
         FROM tmp_terms WHERE parent IS NOT NULL AND child IN
-          (SELECT stanza FROM statements WHERE predicate = 'rdf:type' AND object = 'owl:Class')"""
+          (SELECT subject FROM statements WHERE predicate = 'rdf:type'
+           AND object = 'owl:Class' AND subject NOT LIKE '_:%')"""
     )
 
     # Everything else is an instance


### PR DESCRIPTION
While updating MRO, I ran into an issue with generating the imports. One of the properties in RO was getting both an `rdfs:subPropertyOf` and `rdfs:subClassOf` statement. This was because the query to add the subclasses looks for the stanza instead of the subject, and this RO property was used as the stanza for a blank node subject with a type of `owl:Class`.

Changing these queries to look at the subject instead of the stanza fixes this (although I'm not sure if/how this impacts performance, as we were having better performance when using & indexing on the stanza).