### PR TITLE
Replace sqlite3 and psycopg2 with sqlalchemy

### DIFF
--- a/.github/workflows/postgres-test.yml
+++ b/.github/workflows/postgres-test.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install psycopg2
           pip install .
       - name: Test with pytest
         run: |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ After loading the OWL into the database, we highly recommend creating an index o
 sqlite3 [path-to-database] "CREATE INDEX stanza_idx ON statements(stanza);"
 ```
 
-When using `gizmos` as a Python module, all operations accept a database connection object. For details on the Connection, see [Python Database API Connection Objects](https://www.python.org/dev/peps/pep-0249/#connection-objects). We support [sqlite3](https://docs.python.org/3/library/sqlite3.html) and [psycopg2](https://pypi.org/project/psycopg2/) (PostgreSQL). Using other connection objects may result in unanticipated errors due to slight variations in syntax.
+When using `gizmos` as a Python module, all operations accept a `sqlalchemy` Connection object. For details on the Connection, see [Working with Engines and Connections](https://docs.sqlalchemy.org/en/14/core/connections.html). We currently support SQLite and PostgreSQL. Using other connections may result in unanticipated errors due to slight variations in syntax. Note that if you use a PostgreSQL database, you must install or include `psycopg2` in your requirements.
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,29 @@
 # gizmos
 Utilities for ontology development
 
+### Installation
+
+You can install `gizmos` by running:
+```
+python3 -m pip install ontodev-gizmos
+```
+
+This will include all requirements for using `gizmos` with SQLite databases. If you plan to use a PostgreSQL database, you must also install the [`psycopg2`](https://pypi.org/project/psycopg2/) module:
+```
+python3 -m pip install psycopg2
+````
+
 ### Testing
 
 For development, we recommend installing and testing using:
 ```
 python3 -m pip install -e .
 python3 setup.py pytest
+```
+
+For running the PostgreSQL tests in Docker, you must set up postgres:
+```
+docker run --rm -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres
 ```
 
 There are some dependencies that are test-only (e.g., will not be listed in the project requirements). If you try and run `pytest` alone, it may fail due to missing dependencies.

--- a/gizmos/check.py
+++ b/gizmos/check.py
@@ -1,9 +1,8 @@
 import logging
-import psycopg2
-import sqlite3
 import sys
 
 from argparse import ArgumentParser
+from sqlalchemy.engine.base import Connection
 from .helpers import get_connection
 
 
@@ -33,55 +32,68 @@ def main():
             logger.error("Invalid --limit option: " + lim)
             sys.exit(1)
 
-    conn = get_connection(args.db)
-    check(conn, limit=limit)
+    with get_connection(args.db) as conn:
+        if not check(conn, limit=limit):
+            sys.exit(1)
 
 
-def check(conn, limit=10):
+def check(conn: Connection, limit: int = 10) -> bool:
+    """Check for a 'prefix' and 'statements' table in the database, then check the contents.
+
+    :param conn: sqlalchemy database connection
+    :param limit: max number of messages to log
+    :return: True on success
+    """
     logger = logging.getLogger()
-    cur = conn.cursor()
-    if isinstance(conn, sqlite3.Connection):
-        cur.execute("SELECT name FROM sqlite_master WHERE type='table';")
+    if str(conn.engine.url).startswith("sqlite"):
+        res = conn.execute("SELECT name FROM sqlite_master WHERE type='table';")
     else:
-        cur.execute(
-            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'"
+        res = conn.execute(
+            "SELECT table_name AS name FROM information_schema.tables WHERE table_schema = 'public'"
         )
-    tables = [x[0] for x in cur.fetchall()]
+    tables = [x["name"] for x in res]
 
     if "prefix" not in tables:
         logger.error("missing 'prefix' table")
         prefix_ok = False
     else:
-        prefix_ok = check_prefix(cur)
+        prefix_ok = check_prefix(conn)
 
     statements_ok = True
     if "statements" not in tables:
         logger.error("missing 'statements' table")
         statements_ok = False
     elif prefix_ok:
-        statements_ok = check_statements(cur, limit=limit)
+        statements_ok = check_statements(conn, limit=limit)
 
     if not statements_ok or not prefix_ok:
-        sys.exit(1)
+        return False
+    return True
 
 
-def check_prefix(cur):
-    """Check the structure of the prefix table. It must have the columns 'prefix' and 'base'."""
+def check_prefix(conn: Connection) -> bool:
+    """Check the structure of the prefix table. It must have the columns 'prefix' and 'base'.
+
+    :param conn: sqlalchemy database connection
+    :return: True on success"""
     logger = logging.getLogger()
 
     # Check for required columns
-    if isinstance(cur, sqlite3.Cursor):
-        cur.execute("PRAGMA table_info(prefix)")
-        columns = {x[1]: x[2] for x in cur.fetchall()}
+    if str(conn.engine.url).startswith("sqlite"):
+        res = conn.execute("PRAGMA table_info(prefix)")
     else:
-        columns = get_postgres_columns(cur, "prefix")
+        res = conn.execute(
+            """SELECT column_name AS name, data_type AS type FROM INFORMATION_SCHEMA.COLUMNS
+               WHERE TABLE_NAME = 'prefix';"""
+        )
+    columns = {x["name"]: x["type"] for x in res}
     missing = []
     bad_type = []
     for col in ["prefix", "base"]:
-        coltype = columns.get(col)
+        coltype = columns.get(col).lower()
         if not coltype:
             missing.append(col)
-        elif coltype != "TEXT":
+        elif coltype != "text":
             bad_type.append(col)
     if missing:
         logger.error("'prefix' is missing column(s): " + ", ".join(missing))
@@ -93,8 +105,7 @@ def check_prefix(cur):
     # Check for required prefixes
     missing_prefixes = []
     for prefix in ["owl", "rdf", "rdfs"]:
-        cur.execute(f"SELECT * FROM prefix WHERE prefix = '{prefix}'")
-        res = cur.fetchone()
+        res = conn.execute(f"SELECT * FROM prefix WHERE prefix = '{prefix}'").fetchone()
         if not res:
             missing_prefixes.append(prefix)
     if missing_prefixes:
@@ -103,17 +114,24 @@ def check_prefix(cur):
     return True
 
 
-def check_statements(cur, limit=10):
-    """Check the structure of the statements table then check the values of the columns."""
+def check_statements(conn: Connection, limit: int = 10) -> bool:
+    """Check the structure of the statements table then check the values of the columns.
+
+    :param conn: sqlalchemy database connection
+    :param limit: max number of messages to log
+    :return: True on success"""
     logger = logging.getLogger()
     statements_ok = True
 
     # First check the structure
-    if isinstance(cur, sqlite3.Cursor):
-        cur.execute("PRAGMA table_info(statements)")
-        columns = {x[1]: x[2] for x in cur.fetchall()}
+    if str(conn.engine.url).startswith("sqlite"):
+        res = conn.execute("PRAGMA table_info(statements)")
     else:
-        columns = get_postgres_columns(cur, "statements")
+        res = conn.execute(
+            """SELECT column_name AS name, data_type AS type FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_NAME = 'statements';"""
+        )
+    columns = {x["name"]: x["type"] for x in res}
     missing = []
     bad_type = []
     for col in [
@@ -125,10 +143,10 @@ def check_statements(cur, limit=10):
         "datatype",
         "language",
     ]:
-        coltype = columns.get(col)
+        coltype = columns.get(col).lower()
         if not coltype:
             missing.append(col)
-        elif coltype != "TEXT":
+        elif coltype != "text":
             bad_type.append(col)
     if missing:
         logger.error("'statements' is missing column(s): " + ", ".join(missing))
@@ -139,17 +157,16 @@ def check_statements(cur, limit=10):
 
     # Check for an index on the stanza column, warn if missing (do not fail)
     has_stanza_idx = False
-    if isinstance(cur, sqlite3.Cursor):
-        cur.execute("PRAGMA index_list(statements)")
-        for row in cur.fetchall():
-            index = row[1]
-            cur.execute(f"PRAGMA index_info({index})")
-            col = cur.fetchone()[2]
+    if str(conn.engine.url).startswith("sqlite"):
+        for res in conn.execute("PRAGMA index_list(statements)"):
+            index = res["name"]
+            col_res = conn.execute(f"PRAGMA index_info({index})").fetchone()
+            col = col_res.fetchone()["name"]
             if col == "stanza":
                 has_stanza_idx = True
                 break
     else:
-        cur.execute(
+        results = conn.execute(
             """SELECT a.attname AS column_name
                FROM pg_class t, pg_class i, pg_index ix, pg_attribute a
                WHERE
@@ -160,16 +177,16 @@ def check_statements(cur, limit=10):
                 and t.relkind = 'r'
                 and t.relname = 'statements';"""
         )
-        for row in cur.fetchall():
-            if row[0] == "stanza":
+        for res in results:
+            if res["column_name"] == "stanza":
                 has_stanza_idx = True
                 break
     if not has_stanza_idx:
         logger.warning("missing index on 'stanza' column")
 
     # Get prefixes to check against
-    cur.execute("SELECT prefix, base FROM prefix")
-    prefixes = {x[0]: x[1] for x in cur.fetchall()}
+    res = conn.execute("SELECT prefix, base FROM prefix")
+    prefixes = {x["prefix"]: x["base"] for x in res}
 
     # Check subjects, stanzas, predicates, and objects
     message_count = 0
@@ -177,9 +194,9 @@ def check_statements(cur, limit=10):
         if limit and message_count >= limit:
             # Do not exceed the limit of messages
             break
-        cur.execute(f"SELECT {col} FROM statements")
-        for row in cur.fetchall():
-            value = row[0]
+        results = conn.execute(f"SELECT {col} FROM statements")
+        for res in results:
+            value = res[col]
             if value is None:
                 if col != "object":
                     # Object can be null when there is a value
@@ -212,22 +229,6 @@ def check_statements(cur, limit=10):
                 message_count += 1
                 statements_ok = False
     return statements_ok
-
-
-def get_postgres_columns(cur, table):
-    """Get a dictionary of column name to its type from a PostgreSQL database."""
-    cur.execute(f"SELECT * FROM {table} LIMIT 0")
-    columns = {}
-    for desc in cur.description:
-        type_oid = desc[1]
-        cur.execute(f"SELECT typname FROM pg_type WHERE oid = {type_oid}")
-        res = cur.fetchone()
-        if res:
-            typename = res[0].upper()
-        else:
-            typename = None
-        columns[desc[0]] = typename
-    return columns
 
 
 if __name__ == "__main__":

--- a/gizmos/extract.py
+++ b/gizmos/extract.py
@@ -244,15 +244,11 @@ def extract(
         # Current predicates are IDs or labels - make sure we get all the IDs
         predicate_ids = get_ids(conn, predicates)
 
-    logging.error("4")
-
     # Create the terms table containing parent -> child relationships
     conn.execute("CREATE TABLE tmp_terms(child TEXT, parent TEXT)")
     for term_id in terms.keys():
         query = sql_text("INSERT INTO tmp_terms VALUES (:term_id, NULL)")
         conn.execute(query, term_id=term_id)
-
-    logging.error("5")
 
     # Create tmp predicates table containing all predicates to include
     conn.execute("CREATE TABLE tmp_predicates(predicate TEXT PRIMARY KEY NOT NULL)")

--- a/gizmos/hiccup.py
+++ b/gizmos/hiccup.py
@@ -1,4 +1,4 @@
-def render(prefixes, element, href="?id={curie}", db=None, depth=0):
+def render(prefixes: list, element: list, href: str = "?id={curie}", db: str = None, depth: int = 0) -> str:
     """Render hiccup-style HTML vector as HTML."""
     render_element = element.copy()
     indent = "  " * depth
@@ -40,7 +40,7 @@ def render(prefixes, element, href="?id={curie}", db=None, depth=0):
     return output
 
 
-def render_text(element):
+def render_text(element: list) -> str:
     """Render hiccup-style HTML vector as text."""
     if not isinstance(element, list):
         raise Exception(f"Element is not a list: {element}")

--- a/gizmos/hiccup.py
+++ b/gizmos/hiccup.py
@@ -1,4 +1,6 @@
-def render(prefixes: list, element: list, href: str = "?id={curie}", db: str = None, depth: int = 0) -> str:
+def render(
+    prefixes: list, element: list, href: str = "?id={curie}", db: str = None, depth: int = 0
+) -> str:
     """Render hiccup-style HTML vector as HTML."""
     render_element = element.copy()
     indent = "  " * depth

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 black==19.10b0
 flake8==3.8.3
 html5lib==1.1
-psycopg2
+psycopg2~=2.8.6
 pyRdfa3==3.5.3
 pytest==6.0.2
 rdflib==5.0.0
+setuptools~=57.0.0
+SQLAlchemy~=1.4.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ html5lib==1.1
 pyRdfa3==3.5.3
 pytest==6.0.2
 rdflib==5.0.0
-setuptools~=57.0.0
 SQLAlchemy~=1.4.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 black==19.10b0
 flake8==3.8.3
 html5lib==1.1
-psycopg2~=2.8.6
 pyRdfa3==3.5.3
 pytest==6.0.2
 rdflib==5.0.0

--- a/tests/refactoring/thin2subjectSpecialCases.py
+++ b/tests/refactoring/thin2subjectSpecialCases.py
@@ -1,5 +1,15 @@
+import sys
+
 from copy import deepcopy
 import translationUtil as tUtil
+
+DEBUG = True
+
+
+def log(message):
+    if DEBUG:
+        print(message, file=sys.stderr)
+
 
 def handleAllDisjointClasses(subjects):
     remove = set()

--- a/tests/refactoring/translationUtil.py
+++ b/tests/refactoring/translationUtil.py
@@ -1,3 +1,13 @@
+import sys
+
+DEBUG = True
+
+
+def log(message):
+    if DEBUG:
+        print(message, file=sys.stderr)
+
+
 def firstObject(predicates, predicate):
     """Given a prediate map, return the first 'object'."""
     if predicates.get(predicate):
@@ -5,11 +15,13 @@ def firstObject(predicates, predicate):
             if obj.get("object"):
                 return obj["object"]
 
-def validObject(s,p,o):
+
+def validObject(s, p, o):
     if o:
         return True
     log("Bad object: <{} {} {}>".format(s, p, o))
     return False
+
 
 def isBlankNode(o):
     return o and isinstance(o, str) and o.startswith("_:")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,8 +1,7 @@
-import psycopg2
-import sqlite3
+import gizmos.export
 
-from gizmos.export import export_terms
-from util import test_conn, test_db, create_postgresql_db, create_sqlite_db, compare_graphs
+from sqlalchemy import create_engine
+from util import create_postgresql_db, create_sqlite_db, compare_graphs, postgres_url, sqlite_url
 
 
 def get_diff(actual_lines, expected_lines):
@@ -14,7 +13,7 @@ def get_diff(actual_lines, expected_lines):
 
 
 def export(conn):
-    tsv = export_terms(conn, ["OBI:0100046"], ["CURIE", "label", "definition"], "tsv")
+    tsv = gizmos.export.export(conn, ["OBI:0100046"], ["CURIE", "label", "definition"], "tsv")
     actual_lines = tsv.split("\n")
 
     expected_lines = []
@@ -32,7 +31,7 @@ def export(conn):
 
 
 def export_no_predicates(conn):
-    tsv = export_terms(conn, ["OBI:0100046"], None, "tsv", default_value_format="CURIE")
+    tsv = gizmos.export.export(conn, ["OBI:0100046"], [], "tsv", default_value_format="CURIE")
     with open("test.tsv", "w") as f:
         f.write(tsv)
     actual_lines = tsv.split("\n")
@@ -53,20 +52,24 @@ def export_no_predicates(conn):
 
 
 def test_export_postgresql(create_postgresql_db):
-    with psycopg2.connect(**test_conn) as conn:
+    engine = create_engine(postgres_url)
+    with engine.connect() as conn:
         export(conn)
 
 
 def test_export_no_predicates_postgresql(create_postgresql_db):
-    with psycopg2.connect(**test_conn) as conn:
+    engine = create_engine(postgres_url)
+    with engine.connect() as conn:
         export(conn)
 
 
 def test_export_sqlite(create_sqlite_db):
-    with sqlite3.connect(test_db) as conn:
+    engine = create_engine(sqlite_url)
+    with engine.connect() as conn:
         export(conn)
 
 
 def test_export_no_predicates_sqlite(create_sqlite_db):
-    with sqlite3.connect(test_db) as conn:
+    engine = create_engine(sqlite_url)
+    with engine.connect() as conn:
         export(conn)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,8 +1,6 @@
-import psycopg2
-import sqlite3
-
 from gizmos.search import search
-from util import test_conn, test_db, create_postgresql_db, create_sqlite_db
+from sqlalchemy import create_engine
+from util import create_postgresql_db, create_sqlite_db, postgres_url, sqlite_url
 
 
 def search_text(conn):
@@ -20,10 +18,12 @@ def search_text_with_options(conn):
 
 
 def test_search_postgresql(create_postgresql_db):
-    with psycopg2.connect(**test_conn) as conn:
+    engine = create_engine(postgres_url)
+    with engine.connect() as conn:
         search_text(conn)
 
 
 def test_search_sqlite(create_sqlite_db):
-    with sqlite3.connect(test_db) as conn:
+    engine = create_engine(sqlite_url)
+    with engine.connect() as conn:
         search_text(conn)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,21 +1,17 @@
 import csv
-import logging
 import os
-import psycopg2
 import pytest
-import sqlite3
-import sys
 
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from rdflib.compare import to_isomorphic, graph_diff
-
-test_db = "build/obi.db"
+from sqlalchemy import create_engine
 
 POSTGRES_USER = os.environ.get("POSTGRES_USER", "postgres")
 POSTGRES_PW = os.environ.get("POSTGRES_PW", "postgres")
 POSTGRES_HOST = os.environ.get("POSTGRES_HOST", "localhost")
 POSTGRES_PORT = int(os.environ.get("POSTGRES_PORT", 5432))
-test_conn = {"host": POSTGRES_HOST, "database": "gizmos_test", "user": POSTGRES_USER, "password": POSTGRES_PW, "port": POSTGRES_PORT}
+postgres_url = f"postgresql+psycopg2://{POSTGRES_USER}:{POSTGRES_PW}@{POSTGRES_HOST}:{POSTGRES_PORT}/gizmos_test"
+
+sqlite_url = "sqlite:///" + os.path.abspath("build/obi.db")
 
 
 def dump_ttl_sorted(graph):
@@ -39,66 +35,69 @@ def compare_graphs(actual, expected):
     assert actual_iso == expected_iso
 
 
-def create_db(conn):
-    cur = conn.cursor()
+def add_tables(conn):
+    with conn.begin():
+        conn.execute("DROP TABLE IF EXISTS prefix")
+        conn.execute(
+            "CREATE TABLE prefix (" "  prefix TEXT PRIMARY KEY NOT NULL," "  base TEXT NOT NULL" ")"
+        )
+        with open("tests/resources/prefix.tsv") as f:
+            rows = list(csv.reader(f, delimiter="\t"))
+            for r in rows:
+                conn.execute(f"INSERT INTO prefix VALUES ('{r[0]}', '{r[1]}')")
 
-    cur.execute("DROP TABLE IF EXISTS prefix")
-    cur.execute(
-        "CREATE TABLE prefix (" "  prefix TEXT PRIMARY KEY NOT NULL," "  base TEXT NOT NULL" ")"
-    )
-    with open("tests/resources/prefix.tsv") as f:
-        rows = list(csv.reader(f, delimiter="\t"))
-        for r in rows:
-            cur.execute(f"INSERT INTO prefix VALUES ('{r[0]}', '{r[1]}')")
-
-    cur.execute("DROP TABLE IF EXISTS statements")
-    cur.execute(
-        "CREATE TABLE statements ("
-        "  stanza TEXT,"
-        "  subject TEXT,"
-        "  predicate TEXT,"
-        "  object TEXT,"
-        "  value TEXT,"
-        "  datatype TEXT,"
-        "  language TEXT"
-        ")"
-    )
-    with open("tests/resources/statements.tsv") as f:
-        rows = []
-        for row in csv.reader(f, delimiter="\t"):
-            rows.append([None if not x else x for x in row])
-        for r in rows:
-            query = []
-            for itm in r:
-                if not itm:
-                    query.append("NULL")
-                    continue
-                query.append("'" + itm.replace("'", "''") + "'")
-            query = ", ".join(query)
-            cur.execute(f"INSERT INTO statements VALUES ({query})")
+        conn.execute("DROP TABLE IF EXISTS statements")
+        conn.execute(
+            "CREATE TABLE statements ("
+            "  stanza TEXT,"
+            "  subject TEXT,"
+            "  predicate TEXT,"
+            "  object TEXT,"
+            "  value TEXT,"
+            "  datatype TEXT,"
+            "  language TEXT"
+            ")"
+        )
+        with open("tests/resources/statements.tsv") as f:
+            rows = []
+            for row in csv.reader(f, delimiter="\t"):
+                rows.append([None if not x else x for x in row])
+            for r in rows:
+                query = []
+                for itm in r:
+                    if not itm:
+                        query.append("NULL")
+                        continue
+                    query.append("'" + itm.replace("'", "''").replace("%", "%%") + "'")
+                query = ", ".join(query)
+                conn.execute(f"INSERT INTO statements VALUES ({query})")
 
 
 @pytest.fixture
 def create_postgresql_db():
-    with psycopg2.connect(host=POSTGRES_HOST, user=POSTGRES_USER, password=POSTGRES_PW, port=POSTGRES_PORT) as conn:
-        conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
-        cur = conn.cursor()
-        cur.execute("SELECT datname FROM pg_database WHERE datname = 'gizmos_test';")
-        res = cur.fetchone()
+    engine = create_engine(
+        f"postgresql+psycopg2://{POSTGRES_USER}:{POSTGRES_PW}@{POSTGRES_HOST}:{POSTGRES_PORT}",
+        isolation_level="AUTOCOMMIT",
+    )
+    with engine.connect() as conn:
+        res = conn.execute(
+            "SELECT datname FROM pg_database WHERE datname = 'gizmos_test';"
+        ).fetchone()
         if not res:
-            cur.execute("CREATE DATABASE gizmos_test")
-    with psycopg2.connect(**test_conn) as conn:
-        create_db(conn)
+            with conn.begin():
+                conn.execute("CREATE DATABASE gizmos_test")
+    engine = create_engine(postgres_url)
+    with engine.connect() as conn:
+        add_tables(conn)
 
 
 @pytest.fixture
 def create_sqlite_db():
-    build = os.path.dirname(test_db)
-    if not os.path.isdir(build):
-        os.mkdir(build)
-
-    with sqlite3.connect(test_db) as conn:
-        create_db(conn)
+    if not os.path.isdir("build"):
+        os.mkdir("build")
+    engine = create_engine(sqlite_url)
+    with engine.connect() as conn:
+        add_tables(conn)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #82 
Resolves #87

We should be able to use Gizmos without including `psycopg2` in requirements, unless we're connecting to a PostgreSQL database.

I added a bunch of type hinting to make it easier to ensure we're passing and returning the correct objects. It doesn't change how the code runs at all, but I can remove it if preferred.