### PR TITLE
First pass at HTML search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ This is a TSV or CSV with the following headers:
 
 The config file can be useful for handling multiple imports with different options in a `Makefile`. If your imports all use the same `--intermediates` option and the same predicates, there is no need to specify a config file.
 
-### `gizmos.search`
+### `gizmos.search` - JSON
 
 The `search` module returns a list of JSON objects for use with the tree browser search bar.
 
@@ -190,7 +190,7 @@ Usage in the command line:
 python3 -m gizmos.search [path-to-database] [search-text] > [output-json]
 ```
 
-Usage in Python (with defaults for optional parameters):
+Usage in Python (with defaults for optional parameters - only the first two parameters are required):
 ```python
 json = gizmos.search(     # returns: JSON string
     database_connection,  # Connection: database connection object
@@ -198,7 +198,12 @@ json = gizmos.search(     # returns: JSON string
     label="rdfs:label",   # string: term ID for label
     short_label=None,     # string: term ID for short label
     synonyms=None,        # list: term IDs for synonyms
-    limit=30              # int: max results to return
+    limit=30,             # int: max results to return
+    fmt="json",           # str: output format (json or html)
+    href="?id={curie}",   # str: href format for HTML output (see below)
+    db=None,              # str: db name for HTML output (see below)
+    include_search=False, # boolean: if True, include search bar in HTML (see below)
+    standalone=True       # boolean: if False, do not include HTML headers (see below)
 )
 ```
 
@@ -220,7 +225,21 @@ When both short label and synonym(s) are provided and the matching term has both
 
 Search is run over all three properties, so even if a term's label does not match the text, it may still be returned if the synonym matches.
 
-Finally, the search only returns the first 30 results by default. If you wish to return less or more, you can specify this with `--limit <int>`/`-l <int>`.
+Finally, the search only returns the first 30 results by default. If you wish to return less or more, you can specify this with `--limit <int>`/`-l <int>`. If you wish to include *all* search results, you can include `-l none`.
+
+### `gizmos.search` - HTML
+
+You can also return the search results as an HTML page. The module includes a few additional options to do this, but minimally, you need to include `-f`/`--format`:
+
+```
+python3 -m gizmos.search [path-to-database] [search-text] -f html > [output-html]
+```
+
+The additional options for use with the HTML output are:
+* `-H`/`--href`: the query string format to use in links to search results, see [Tree Links](#tree-links)
+* `d`/`--db-name`: the name of the database if you want to include it in your `href`
+* `-r`/`--include-search`: flag to include a search bar at the top of the search results page
+* `-c`/`--contents-only`: flag to only produce HTML content without the `<html>` and `<body>` tags
 
 ### `gizmos.tree`
 

--- a/gizmos/search.py
+++ b/gizmos/search.py
@@ -56,8 +56,7 @@ def main():
         try:
             limit = int(args.limit)
         except ValueError:
-            print("ERROR: --limit must be an integer")
-            sys.exit(1)
+            raise RuntimeError("--limit must be an integer")
 
     if args.href:
         href = args.href

--- a/gizmos/search.py
+++ b/gizmos/search.py
@@ -3,9 +3,18 @@ import sys
 
 from argparse import ArgumentParser
 from collections import defaultdict
+from typing import Optional
+
 from sqlalchemy.engine.base import Connection
 from sqlalchemy.sql.expression import text as sql_text
 from .helpers import get_connection
+from .hiccup import render
+
+# Stylesheets & JS scripts
+bootstrap_css = "https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
+bootstrap_js = "https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
+popper_js = "https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
+typeahead_js = "https://cdnjs.cloudflare.com/ajax/libs/typeahead.js/0.11.1/typeahead.bundle.min.js"
 
 
 def main():
@@ -22,8 +31,43 @@ def main():
         help="A property to include as synonym, default is excluded",
         action="append",
     )
-    p.add_argument("-l", "--limit", help="Limit for number of results", type=int, default=30)
+    p.add_argument("-l", "--limit", help="Limit for number of results", default=30)
+    p.add_argument("-f", "--format", help="", default="json")
+    p.add_argument("-H", "--href", help="Format string to convert CURIEs to tree links")
+    p.add_argument(
+        "-d",
+        "--db-name",
+        help="If provided, include 'db' param in query string with the given name",
+    )
+    p.add_argument(
+        "-r", "--include-search", help="If provided, include a search bar", action="store_true"
+    )
+    p.add_argument(
+        "-c",
+        "--contents-only",
+        action="store_true",
+        help="If provided, render HTML without the roots",
+    )
     args = p.parse_args()
+
+    if args.limit == "none":
+        limit = None
+    else:
+        try:
+            limit = int(args.limit)
+        except ValueError:
+            print("ERROR: --limit must be an integer")
+            sys.exit(1)
+
+    if args.href:
+        href = args.href
+        if "{curie}" not in href:
+            raise RuntimeError("The --href argument must contain '{curie}'")
+    else:
+        href = "?id={curie}"
+        if args.db_name:
+            href += "&db={db}"
+
     conn = get_connection(args.db)
     sys.stdout.write(
         search(
@@ -32,7 +76,12 @@ def main():
             label=args.label,
             short_label=args.short_label,
             synonyms=args.synonyms,
-            limit=args.limit,
+            limit=limit,
+            fmt=args.format,
+            href=href,
+            db=args.db_name,
+            include_search=args.include_search,
+            standalone=not args.contents_only,
         )
     )
 
@@ -43,13 +92,23 @@ def search(
     label: str = "rdfs:label",
     short_label: str = None,
     synonyms: list = None,
-    limit: int = 30,
+    limit: Optional[int] = 30,
+    fmt: str = "json",
+    href: str = "?id={curie}",
+    db: Optional[str] = None,
+    include_search: bool = False,
+    standalone: bool = True,
 ) -> str:
     """Return a string containing the search results in JSON format."""
     res = get_search_results(
         conn, search_text, label=label, short_label=short_label, synonyms=synonyms, limit=limit
     )
-    return json.dumps(res, indent=4)
+    if fmt == "json":
+        return json.dumps(res, indent=4)
+    else:
+        return render_html(
+            res, search_text, href=href, db=db, include_search=include_search, standalone=standalone
+        )
 
 
 def get_search_results(
@@ -58,7 +117,7 @@ def get_search_results(
     label: str = "rdfs:label",
     short_label: str = None,
     synonyms: list = None,
-    limit: int = 30,
+    limit: Optional[int] = 30,
 ) -> list:
     """Return a list containing search results. Each search result has:
     - id
@@ -100,7 +159,9 @@ def get_search_results(
                     """SELECT DISTINCT subject, value FROM statements
                     WHERE predicate = :short_label AND lower(value) LIKE :text"""
                 )
-                results = conn.execute(query, short_label=short_label, text=f"%%{search_text.lower()}%%")
+                results = conn.execute(
+                    query, short_label=short_label, text=f"%%{search_text.lower()}%%"
+                )
                 for res in results:
                     term_id = res["subject"]
                     if term_id not in names:
@@ -197,7 +258,9 @@ def get_search_results(
         }
 
     # Order the matched values by length, shortest first, regardless of matched property
-    term_to_match = sorted(term_to_match, key=lambda key: len(term_to_match[key]))[:limit]
+    term_to_match = sorted(term_to_match, key=lambda key: len(term_to_match[key]))
+    if limit:
+        term_to_match = term_to_match[:limit]
     res = []
     i = 1
     for term in term_to_match:
@@ -206,6 +269,272 @@ def get_search_results(
         res.append(details)
         i += 1
     return res
+
+
+def render_html(
+    res: list,
+    text: str,
+    href: str = "?id={curie}",
+    db: Optional[str] = None,
+    include_search: bool = False,
+    standalone: bool = True,
+) -> str:
+    body = ["div", {"class": "container"}]
+    if include_search:
+        form = [
+            "form",
+            {"class": "form-row mt-2 mb-2", "method": "get"},
+            [
+                "input",
+                {
+                    "id": f"statements-typeahead",
+                    "name": "search_text",
+                    "class": "typeahead form-control",
+                    "type": "text",
+                    "value": "",
+                    "placeholder": "Search",
+                },
+            ],
+        ]
+        if db:
+            form.append(["input", {"name": "db", "value": db, "type": "hidden"}])
+        body.append(form)
+
+    body.append(["div", {"class": "row"}, ["h2", f"Search results for '{text}'"]])
+    body.append(
+        [
+            "div",
+            {"class": "row"},
+            ["p", {"class": "font-italic"}, "Showing ", ["b", str(len(res))], " results"],
+        ]
+    )
+    for itm in res:
+        term_id = itm["id"]
+        link = href.replace("{curie}", term_id)
+        if db:
+            link = link.replace("{db}", db)
+        href_ele = ["a", {"href": link}, itm["label"]]
+        ele = ["p", {"class": "lead"}, href_ele, "&nbsp;&nbsp;&nbsp;", ["code", term_id]]
+        body.append(["div", {"class": "row"}, ele])
+
+    if include_search:
+        # JQuery
+        body.append(
+            [
+                "script",
+                {"type": "text/javascript", "src": "https://code.jquery.com/jquery-3.5.1.min.js",},
+            ]
+        )
+
+        # Add JS imports for running search
+        body.append(["script", {"type": "text/javascript", "src": popper_js}])
+        body.append(["script", {"type": "text/javascript", "src": bootstrap_js}])
+        body.append(["script", {"type": "text/javascript", "src": typeahead_js}])
+
+        # Built the href to return when you select a term
+        href_split = href.split("{curie}")
+        before = href_split[0]
+        if db:
+            before = before.format(db=db)
+        after = href_split[1]
+        if db:
+            after = after.format(db=db)
+        js_funct = f'str.push("{before}" + encodeURIComponent(obj[p]) + "{after}");'
+
+        # Build the href to return names JSON
+        remote = "'?text=%QUERY&format=json'"
+        if db:
+            # Add tree name to query params
+            remote = f"'?db={db}&text=%QUERY&format=json'"
+        js = (
+            """
+        $('#search-form').submit(function () {
+            $(this)
+                .find('input[name]')
+                .filter(function () {
+                    return !this.value;
+                })
+                .prop('name', '');
+        });
+        function jump(currentPage) {
+          newPage = prompt("Jump to page", currentPage);
+          if (newPage) {
+            href = window.location.href.replace("page="+currentPage, "page="+newPage);
+            window.location.href = href;
+          }
+        }
+        function configure_typeahead(node) {
+          if (!node.id || !node.id.endsWith("-typeahead")) {
+            return;
+          }
+          table = node.id.replace("-typeahead", "");
+          var bloodhound = new Bloodhound({
+            datumTokenizer: Bloodhound.tokenizers.obj.nonword('short_label', 'label', 'synonym'),
+            queryTokenizer: Bloodhound.tokenizers.nonword,
+            sorter: function(a, b) {
+              return a.order - b.order;
+            },
+            remote: {
+              url: """
+            + remote
+            + """,
+             wildcard: '%QUERY',
+             transform : function(response) {
+                 return bloodhound.sorter(response);
+             }
+           }
+         });
+         $(node).typeahead({
+           minLength: 0,
+           hint: false,
+           highlight: true
+         }, {
+           name: table,
+           source: bloodhound,
+           display: function(item) {
+             if (item.label && item.short_label && item.synonym) {
+               return item.short_label + ' - ' + item.label + ' - ' + item.synonym;
+             } else if (item.label && item.short_label) {
+               return item.short_label + ' - ' + item.label;
+             } else if (item.label && item.synonym) {
+               return item.label + ' - ' + item.synonym;
+             } else if (item.short_label && item.synonym) {
+               return item.short_label + ' - ' + item.synonym;
+             } else if (item.short_label && !item.label) {
+               return item.short_label;
+             } else {
+               return item.label;
+             }
+           },
+           limit: 40
+         });
+         $(node).bind('click', function(e) {
+           $(node).select();
+         });
+         $(node).bind('typeahead:select', function(ev, suggestion) {
+           $(node).prev().val(suggestion.id);
+           go(table, suggestion.id);
+         });
+         $(node).bind('keypress',function(e) {
+           if(e.which == 13) {
+             go(table, $('#' + table + '-hidden').val());
+           }
+         });
+       }
+       $('.typeahead').each(function() { configure_typeahead(this); });
+       function go(table, value) {
+         q = {}
+         table = table.replace('_all', '');
+         q[table] = value
+         window.location = query(q);
+       }
+       function query(obj) {
+         var str = [];
+         for (var p in obj)
+           if (obj.hasOwnProperty(p)) {
+             """
+            + js_funct
+            + """
+           }
+         return str.join("&");
+       }"""
+        )
+        body.append(["script", {"type": "text/javascript"}, js])
+
+    if standalone:
+        # HTML Headers & CSS
+        head = [
+            "head",
+            ["meta", {"charset": "utf-8"}],
+            [
+                "meta",
+                {
+                    "name": "viewport",
+                    "content": "width=device-width, initial-scale=1, shrink-to-fit=no",
+                },
+            ],
+            ["link", {"rel": "stylesheet", "href": bootstrap_css, "crossorigin": "anonymous"}],
+            ["link", {"rel": "stylesheet", "href": "../style.css"}],
+            # ["title", title]
+            [
+                "style",
+                """
+                .tt-dataset {
+          max-height: 300px;
+          overflow-y: scroll;
+        }
+        span.twitter-typeahead .tt-menu {
+          cursor: pointer;
+        }
+        .dropdown-menu, span.twitter-typeahead .tt-menu {
+          position: absolute;
+          top: 100%;
+          left: 0;
+          z-index: 1000;
+          display: none;
+          float: left;
+          min-width: 160px;
+          padding: 5px 0;
+          margin: 2px 0 0;
+          font-size: 1rem;
+          color: #373a3c;
+          text-align: left;
+          list-style: none;
+          background-color: #fff;
+          background-clip: padding-box;
+          border: 1px solid rgba(0, 0, 0, 0.15);
+          border-radius: 0.25rem; }
+        span.twitter-typeahead .tt-suggestion {
+          display: block;
+          width: 100%;
+          padding: 3px 20px;
+          clear: both;
+          font-weight: normal;
+          line-height: 1.5;
+          color: #373a3c;
+          text-align: inherit;
+          white-space: nowrap;
+          background: none;
+          border: 0; }
+        span.twitter-typeahead .tt-suggestion:focus,
+        .dropdown-item:hover,
+        span.twitter-typeahead .tt-suggestion:hover {
+            color: #2b2d2f;
+            text-decoration: none;
+            background-color: #f5f5f5; }
+        span.twitter-typeahead .active.tt-suggestion,
+        span.twitter-typeahead .tt-suggestion.tt-cursor,
+        span.twitter-typeahead .active.tt-suggestion:focus,
+        span.twitter-typeahead .tt-suggestion.tt-cursor:focus,
+        span.twitter-typeahead .active.tt-suggestion:hover,
+        span.twitter-typeahead .tt-suggestion.tt-cursor:hover {
+            color: #fff;
+            text-decoration: none;
+            background-color: #0275d8;
+            outline: 0; }
+        span.twitter-typeahead .disabled.tt-suggestion,
+        span.twitter-typeahead .disabled.tt-suggestion:focus,
+        span.twitter-typeahead .disabled.tt-suggestion:hover {
+            color: #818a91; }
+        span.twitter-typeahead .disabled.tt-suggestion:focus,
+        span.twitter-typeahead .disabled.tt-suggestion:hover {
+            text-decoration: none;
+            cursor: not-allowed;
+            background-color: transparent;
+            background-image: none;
+            filter: "progid:DXImageTransform.Microsoft.gradient(enabled = false)"; }
+        span.twitter-typeahead {
+          width: 100%; }
+          .input-group span.twitter-typeahead {
+            display: block !important; }
+            .input-group span.twitter-typeahead .tt-menu {
+              top: 2.375rem !important; }""",
+            ],
+        ]
+        html = ["html", head, body]
+    else:
+        html = body
+    return render([], html)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #96 

See demo on the ONTIE DROID: https://droid.ontodev.com/ONTIE/branches/html-search-demo/views/src/scripts/tree.sh?id=DOID%3A0060499&db=ontie

If you type in the search box, typeahead will still display predictive text. If you click one of the search results from typeahead or press the down arrow and hit enter while one of those search results is highlighted, it will take you directly to that term. Alternatively, if you type in some text and hit enter without highlighting a search result, it will take you to a search result page: https://droid.ontodev.com/ONTIE/branches/html-search-demo/views/src/scripts/tree.sh?search_text=immune&db=ontie

From there, you can click on a term to go to that term's page. This is the same way that the OLS search bar works, as far as I can tell.

This is a first pass at the HTML display for search results, I'm happy to update this page as needed. Here's some info from the docs on using it in the command line. There are quite a few new args, but you can ignore them if you're using the JSON output.

### `gizmos.search` - HTML

You can also return the search results as an HTML page. The module includes a few additional options to do this, but minimally, you need to include `-f`/`--format`:

```
python3 -m gizmos.search [path-to-database] [search-text] -f html > [output-html]
```

The additional options for use with the HTML output are:
* `-H`/`--href`: the query string format to use in links to search results, see [Tree Links](#tree-links)
* `d`/`--db-name`: the name of the database if you want to include it in your `href`
* `-r`/`--include-search`: flag to include a search bar at the top of the search results page
* `-c`/`--contents-only`: flag to only produce HTML content without the `<html>` and `<body>` tags

---

... and here's how I've implemented it for ONTIE in a `tree.sh` script: https://github.com/IEDB/ONTIE/blob/html-search-demo/src/scripts/tree.sh

The relevant code is that the search bar now directs to `?search_text=[SEARCH_TEXT]&db=[DB]` (if a db name has been provided) when you hit enter without highlighting a typeahead result.